### PR TITLE
Adding Unit Tests for 8-bit Arithmetic Instructions ADD and ADC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ FetchContent_MakeAvailable(Catch2)
 add_executable(tests
   tests/flags_register_tests.cpp
   tests/register_tests.cpp
+  tests/cpu_tests.cpp
 )
 
 target_include_directories(tests PRIVATE

--- a/include/cpu.hpp
+++ b/include/cpu.hpp
@@ -24,73 +24,72 @@ class CPU {
                 /* 8-bit Arithmetic Operations */
 
                 // ADD Instruction adds specified register contents to register A
-                case InstructionType::ADD:
+                case InstructionType::ADD: {
+                    uint8_t value = 0;
+
                     switch (instruction.target) {
+                        case ArithmeticTarget::A:
+                            value = registers.a;
+                            break;
                         case ArithmeticTarget::B:
-                            uint8_t value = registers.b;
-                            uint8_t new_value = add(value);
-
-                            registers.a = new_value;
+                            value = registers.b;
+                            break;
                         case ArithmeticTarget::C:
-                            uint8_t value = registers.c;
-                            uint8_t new_value = add(value);
-
-                            registers.a = new_value;
+                            value = registers.c;
+                            break;
                         case ArithmeticTarget::D:
-                            uint8_t value = registers.d;
-                            uint8_t new_value = add(value);
-
-                            registers.a = new_value;
+                            value = registers.d;
+                            break;
                         case ArithmeticTarget::E:
-                            uint8_t value = registers.e;
-                            uint8_t new_value = add(value);
-
-                            registers.a = new_value;
+                            value = registers.e;
+                            break;
                         case ArithmeticTarget::H:
-                            uint8_t value = registers.h;
-                            uint8_t new_value = add(value);
-
-                            registers.a = new_value;
+                            value = registers.h;
+                            break;
                         case ArithmeticTarget::L:
-                            uint8_t value = registers.l;
-                            uint8_t new_value = add(value);
-
-                            registers.a = new_value;
+                            value = registers.l;
+                            break;
+                        default:
+                            break;
                     }
 
-                case InstructionType::ADC:
+                    uint8_t new_value = add(value);
+                    registers.a = new_value;
+
+                    break;
+                }
+                case InstructionType::ADC: {
+                    uint8_t value = 0;
+
                     switch (instruction.target) {
+                        case ArithmeticTarget::A:
+                            value = registers.a;
+                            break;
                         case ArithmeticTarget::B:
-                            uint8_t value = registers.b;
-                            uint8_t new_value = adc(value);
-
-                            registers.a = new_value;
+                            value = registers.b;
+                            break;
                         case ArithmeticTarget::C:
-                            uint8_t value = registers.c;
-                            uint8_t new_value = adc(value);
-
-                            registers.a = new_value;
+                            value = registers.c;
+                            break;
                         case ArithmeticTarget::D:
-                            uint8_t value = registers.d;
-                            uint8_t new_value = adc(value);
-
-                            registers.a = new_value;
+                            value = registers.d;
+                            break;
                         case ArithmeticTarget::E:
-                            uint8_t value = registers.e;
-                            uint8_t new_value = adc(value);
-
-                            registers.a = new_value;
+                            value = registers.e;
+                            break;
                         case ArithmeticTarget::H:
-                            uint8_t value = registers.h;
-                            uint8_t new_value = adc(value);
-
-                            registers.a = new_value;
+                            value = registers.h;
+                            break;
                         case ArithmeticTarget::L:
-                            uint8_t value = registers.l;
-                            uint8_t new_value = adc(value);
-
-                            registers.a = new_value;
+                            value = registers.l;
+                            break;
                     }
+
+                    uint8_t new_value = adc(value);
+                    registers.a = new_value;
+
+                    break;
+                }
 
                 default:
                     // TODO: support more instructions

--- a/tests/cpu_tests.cpp
+++ b/tests/cpu_tests.cpp
@@ -38,19 +38,48 @@ TEST_CASE("CPU 8-bit Arithmetic Unit Tests - ADD", "[cpu][8-bit][add]") {
         REQUIRE(c1.registers.f.half_carry == false);
     }
 
-    // SECTION ("ADD w/ Overflow") {
-    //     CPU c2;
+    SECTION ("ADD w/ Overflow") {
+        CPU c2;
 
+        c2.registers.a = 200;
+        c2.registers.b = 100;
 
-    // }
+        c2.execute(instruct);
 
-    // SECTION ("ADD w/ Zeroes") {
-    //     CPU c3;
+        REQUIRE(c2.registers.a == 44);
+        REQUIRE(c2.registers.f.zero == false);
+        REQUIRE(c2.registers.f.subtract == false);
+        REQUIRE(c2.registers.f.carry == true);
+        REQUIRE(c2.registers.f.half_carry == false);
+    }
 
+    SECTION ("ADD w/ Zeroes") {
+        CPU c3;
 
-    // }
+        c3.registers.a = 0;
+        c3.registers.b = 0;
 
-    // SECTION ("ADD w/ Half Carry") {
-    //     CPU c4;
-    // }
+        c3.execute(instruct);
+
+        REQUIRE(c3.registers.a == 0);
+        REQUIRE(c3.registers.f.zero == true);
+        REQUIRE(c3.registers.f.subtract == false);
+        REQUIRE(c3.registers.f.carry == false);
+        REQUIRE(c3.registers.f.half_carry == false);
+    }
+
+    SECTION ("ADD w/ Half Carry") {
+        CPU c4;
+
+        c4.registers.a = 15;
+        c4.registers.b = 1;
+
+        c4.execute(instruct);
+
+        REQUIRE(c4.registers.a == 16);
+        REQUIRE(c4.registers.f.zero == false);
+        REQUIRE(c4.registers.f.subtract == false);
+        REQUIRE(c4.registers.f.carry == false);
+        REQUIRE(c4.registers.f.half_carry == true);
+    }
 }

--- a/tests/cpu_tests.cpp
+++ b/tests/cpu_tests.cpp
@@ -1,0 +1,56 @@
+#include <catch2/catch_test_macros.hpp>
+#include <cpu.hpp>
+
+TEST_CASE("Default constructor initializes CPU successfully", "[cpu]") {
+    CPU c;
+
+    REQUIRE(c.registers.a == 0);
+    REQUIRE(c.registers.b == 0);
+    REQUIRE(c.registers.c == 0);
+    REQUIRE(c.registers.d == 0);
+    REQUIRE(c.registers.e == 0);
+    REQUIRE(c.registers.h == 0);
+    REQUIRE(c.registers.l == 0);
+
+    REQUIRE(c.registers.f.zero == false);
+    REQUIRE(c.registers.f.subtract == false);
+    REQUIRE(c.registers.f.half_carry == false);
+    REQUIRE(c.registers.f.carry == false);
+}
+
+TEST_CASE("CPU 8-bit Arithmetic Unit Tests - ADD", "[cpu][8-bit][add]") {
+    Instruction instruct;
+    instruct.type = InstructionType::ADD;
+    instruct.target = ArithmeticTarget::B;
+
+    SECTION ("ADD w/o Overflow") {
+        CPU c1;
+
+        c1.registers.a = 1;
+        c1.registers.b = 1;
+
+        c1.execute(instruct);
+
+        REQUIRE(c1.registers.a == 2);
+        REQUIRE(c1.registers.f.zero == false);
+        REQUIRE(c1.registers.f.subtract == false);
+        REQUIRE(c1.registers.f.carry == false);
+        REQUIRE(c1.registers.f.half_carry == false);
+    }
+
+    // SECTION ("ADD w/ Overflow") {
+    //     CPU c2;
+
+
+    // }
+
+    // SECTION ("ADD w/ Zeroes") {
+    //     CPU c3;
+
+
+    // }
+
+    // SECTION ("ADD w/ Half Carry") {
+    //     CPU c4;
+    // }
+}

--- a/tests/cpu_tests.cpp
+++ b/tests/cpu_tests.cpp
@@ -18,7 +18,7 @@ TEST_CASE("Default constructor initializes CPU successfully", "[cpu]") {
     REQUIRE(c.registers.f.carry == false);
 }
 
-TEST_CASE("CPU 8-bit Arithmetic Unit Tests - ADD", "[cpu][8-bit][add]") {
+TEST_CASE("ADD Unit Tests", "[cpu][8-bit][add]") {
     Instruction instruct;
     instruct.type = InstructionType::ADD;
     instruct.target = ArithmeticTarget::B;
@@ -81,5 +81,75 @@ TEST_CASE("CPU 8-bit Arithmetic Unit Tests - ADD", "[cpu][8-bit][add]") {
         REQUIRE(c4.registers.f.subtract == false);
         REQUIRE(c4.registers.f.carry == false);
         REQUIRE(c4.registers.f.half_carry == true);
+    }
+}
+
+TEST_CASE("ADC Unit Tests", "[cpu][8-bit][adc]") {
+    Instruction instruct;
+    instruct.type = InstructionType::ADC;
+    instruct.target = ArithmeticTarget::B;
+
+    SECTION ("ADC w/o Overflow - No Carry") {
+        CPU c1;
+
+        c1.registers.a = 1;
+        c1.registers.b = 1;
+        c1.registers.f.carry = 0;
+
+        c1.execute(instruct);
+
+        REQUIRE(c1.registers.a == 2);
+        REQUIRE(c1.registers.f.zero == false);
+        REQUIRE(c1.registers.f.subtract == false);
+        REQUIRE(c1.registers.f.carry == false);
+        REQUIRE(c1.registers.f.half_carry == false);
+    }
+
+    SECTION ("ADC w/o Overflow - Carry") {
+        CPU c2;
+
+        c2.registers.a = 1;
+        c2.registers.b = 1;
+        c2.registers.f.carry = 1;
+
+        c2.execute(instruct);
+
+        REQUIRE(c2.registers.a == 3);
+        REQUIRE(c2.registers.f.zero == false);
+        REQUIRE(c2.registers.f.subtract == false);
+        REQUIRE(c2.registers.f.carry == false);
+        REQUIRE(c2.registers.f.half_carry == false);
+    }
+
+    SECTION ("ADC Near Overflow - No Carry") {
+        CPU c3;
+
+        c3.registers.a = 254;
+        c3.registers.b = 1;
+        c3.registers.f.carry = 0;
+
+        c3.execute(instruct);
+
+        REQUIRE(c3.registers.a == 255);
+        REQUIRE(c3.registers.f.zero == false);
+        REQUIRE(c3.registers.f.subtract == false);
+        REQUIRE(c3.registers.f.carry == false);
+        REQUIRE(c3.registers.f.half_carry == false);
+    }
+
+    SECTION ("ADC Near Overflow - Carry") {
+        CPU c4;
+
+        c4.registers.a = 254;
+        c4.registers.b = 1;
+        c4.registers.f.carry = 1;
+
+        c4.execute(instruct);
+
+        REQUIRE(c4.registers.a == 0);
+        REQUIRE(c4.registers.f.zero == true);
+        REQUIRE(c4.registers.f.subtract == false);
+        REQUIRE(c4.registers.f.carry == true);
+        REQUIRE(c4.registers.f.half_carry == false);
     }
 }


### PR DESCRIPTION
# Issue
https://github.com/Sam-Coburn/gameboy_emulator/issues/1

# Changes
- Added unit tests for ADD and ADC
- Refactored ADD and ADC to account for runtime errors due to bugs with switch case scope

# Test Results
<img width="692" height="497" alt="Screenshot 2026-04-13 at 6 11 05 PM" src="https://github.com/user-attachments/assets/653fe4b0-7267-40f1-a883-0f80af4e657d" />
The code compiles successfully and all unit test cases pass successfully