### PR TITLE
Implementing 8-bit Arithmetic Instructions in CPU Class

### DIFF
--- a/include/cpu.hpp
+++ b/include/cpu.hpp
@@ -7,7 +7,7 @@ enum class ArithmeticTarget {
 };
 
 enum class InstructionType {
-    ADD, ADC, SUB, SBC
+    ADD, ADC, SUB, SBC, AND
 };
 
 struct Instruction {
@@ -161,6 +161,40 @@ class CPU {
                     break;
                 }
 
+                // AND Instruction performs bitwise AND operation using specified register contents with register A
+                case InstructionType::AND: {
+                    uint8_t value = 0;
+
+                    switch (instruction.target) {
+                        case ArithmeticTarget::A:
+                            value = registers.a;
+                            break;
+                        case ArithmeticTarget::B:
+                            value = registers.b;
+                            break;
+                        case ArithmeticTarget::C:
+                            value = registers.c;
+                            break;
+                        case ArithmeticTarget::D:
+                            value = registers.d;
+                            break;
+                        case ArithmeticTarget::E:
+                            value = registers.e;
+                            break;
+                        case ArithmeticTarget::H:
+                            value = registers.h;
+                            break;
+                        case ArithmeticTarget::L:
+                            value = registers.l;
+                            break;
+                    }
+
+                    uint8_t new_value = bitwise_and(value);
+                    registers.a = new_value;
+
+                    break;
+                }
+
                 default:
                     // TODO: support more instructions
                     break;
@@ -215,6 +249,17 @@ class CPU {
             registers.f.subtract = true;
             registers.f.carry = underflowed;
             registers.f.half_carry = ((value + registers.f.carry) & 0xF) > (registers.a & 0xF);
+
+            return result;
+        }
+
+        uint8_t bitwise_and(uint8_t value) {
+            uint8_t result = registers.a & value;
+
+            registers.f.zero = result == 0;
+            registers.f.subtract = false;
+            registers.f.carry = false;
+            registers.f.half_carry = true;
 
             return result;
         }

--- a/include/cpu.hpp
+++ b/include/cpu.hpp
@@ -7,7 +7,7 @@ enum class ArithmeticTarget {
 };
 
 enum class InstructionType {
-    ADD, ADC
+    ADD, ADC, SUB
 };
 
 struct Instruction {
@@ -58,6 +58,8 @@ class CPU {
 
                     break;
                 }
+
+                // ADC Instruction adds specified register contents + current carry flag value to register A
                 case InstructionType::ADC: {
                     uint8_t value = 0;
 
@@ -86,6 +88,40 @@ class CPU {
                     }
 
                     uint8_t new_value = adc(value);
+                    registers.a = new_value;
+
+                    break;
+                }
+
+                // SUB Instruction subtracts specfified register contents from register A
+                case InstructionType::SUB: {
+                    uint8_t value = 0;
+
+                    switch (instruction.target) {
+                        case ArithmeticTarget::A:
+                            value = registers.a;
+                            break;
+                        case ArithmeticTarget::B:
+                            value = registers.b;
+                            break;
+                        case ArithmeticTarget::C:
+                            value = registers.c;
+                            break;
+                        case ArithmeticTarget::D:
+                            value = registers.d;
+                            break;
+                        case ArithmeticTarget::E:
+                            value = registers.e;
+                            break;
+                        case ArithmeticTarget::H:
+                            value = registers.h;
+                            break;
+                        case ArithmeticTarget::L:
+                            value = registers.l;
+                            break;
+                    }
+
+                    uint8_t new_value = sub(value);
                     registers.a = new_value;
 
                     break;
@@ -121,6 +157,18 @@ class CPU {
             registers.f.subtract = false;
             registers.f.carry = overflowed;
             registers.f.half_carry = (registers.a & 0xF) + (value & 0xF) > 0xF; // Same logic as for add()
+
+            return result;
+        }
+
+        uint8_t sub(uint8_t value) {
+            uint8_t result = registers.a - value;
+            bool underflowed = value > registers.a;
+
+            registers.f.zero = result == 0;
+            registers.f.subtract = true;
+            registers.f.carry = underflowed;
+            registers.f.half_carry = (value & 0xF) > (registers.a & 0xF);
 
             return result;
         }

--- a/include/cpu.hpp
+++ b/include/cpu.hpp
@@ -8,7 +8,7 @@ enum class ArithmeticTarget {
 
 enum class InstructionType {
     ADD, ADC, SUB, SBC, AND,
-    OR, XOR, CP, INC
+    OR, XOR, CP, INC, DEC
 };
 
 struct Instruction {
@@ -326,6 +326,35 @@ class CPU {
                     break;
                 }
 
+                // DEC Instruction increments value of target register
+                case InstructionType::DEC: {
+                    switch (instruction.target) {
+                        case ArithmeticTarget::A:
+                            registers.a = dec(registers.a);
+                            break;
+                        case ArithmeticTarget::B:
+                            registers.b = dec(registers.b);
+                            break;
+                        case ArithmeticTarget::C:
+                            registers.c = dec(registers.c);
+                            break;
+                        case ArithmeticTarget::D:
+                            registers.d = dec(registers.d);
+                            break;
+                        case ArithmeticTarget::E:
+                            registers.e = dec(registers.e);
+                            break;
+                        case ArithmeticTarget::H:
+                            registers.h = dec(registers.h);
+                            break;
+                        case ArithmeticTarget::L:
+                            registers.l = dec(registers.l);
+                            break;
+                    }
+
+                    break;
+                }
+
                 default:
                     // TODO: support more instructions
                     break;
@@ -424,6 +453,17 @@ class CPU {
             registers.f.subtract = false;
             registers.f.carry = registers.f.carry; // INC doesnt affect the carry flag, it's left alone
             registers.f.half_carry = (value & 0xF) + (1 & 0xF) > 0xF;
+
+            return result;
+        }
+
+        uint8_t dec(uint8_t value) {
+            uint8_t result = value - 1;
+
+            registers.f.zero = result == 0;
+            registers.f.subtract = true;
+            registers.f.carry = registers.f.carry; // DEC doesnt affect the carry flag, it's left alone
+            registers.f.half_carry = (1 & 0xF) > (value & 0xF);
 
             return result;
         }

--- a/include/cpu.hpp
+++ b/include/cpu.hpp
@@ -7,7 +7,8 @@ enum class ArithmeticTarget {
 };
 
 enum class InstructionType {
-    ADD, ADC, SUB, SBC, AND
+    ADD, ADC, SUB, SBC, AND,
+    OR
 };
 
 struct Instruction {
@@ -195,6 +196,40 @@ class CPU {
                     break;
                 }
 
+                // AND Instruction performs bitwise OR operation using specified register contents with register A
+                case InstructionType::OR: {
+                    uint8_t value = 0;
+
+                    switch (instruction.target) {
+                        case ArithmeticTarget::A:
+                            value = registers.a;
+                            break;
+                        case ArithmeticTarget::B:
+                            value = registers.b;
+                            break;
+                        case ArithmeticTarget::C:
+                            value = registers.c;
+                            break;
+                        case ArithmeticTarget::D:
+                            value = registers.d;
+                            break;
+                        case ArithmeticTarget::E:
+                            value = registers.e;
+                            break;
+                        case ArithmeticTarget::H:
+                            value = registers.h;
+                            break;
+                        case ArithmeticTarget::L:
+                            value = registers.l;
+                            break;
+                    }
+
+                    uint8_t new_value = bitwise_or(value);
+                    registers.a = new_value;
+
+                    break;
+                }
+
                 default:
                     // TODO: support more instructions
                     break;
@@ -260,6 +295,17 @@ class CPU {
             registers.f.subtract = false;
             registers.f.carry = false;
             registers.f.half_carry = true;
+
+            return result;
+        }
+
+        uint8_t bitwise_or(uint8_t value) {
+            uint8_t result = registers.a & value;
+
+            registers.f.zero = result == 0;
+            registers.f.subtract = false;
+            registers.f.carry = false;
+            registers.f.half_carry = false;
 
             return result;
         }

--- a/include/cpu.hpp
+++ b/include/cpu.hpp
@@ -8,7 +8,7 @@ enum class ArithmeticTarget {
 
 enum class InstructionType {
     ADD, ADC, SUB, SBC, AND,
-    OR, XOR, CP
+    OR, XOR, CP, INC
 };
 
 struct Instruction {
@@ -297,6 +297,35 @@ class CPU {
                     break;
                 }
 
+                // INC Instruction increments value of target register
+                case InstructionType::INC: {
+                    switch (instruction.target) {
+                        case ArithmeticTarget::A:
+                            registers.a = inc(registers.a);
+                            break;
+                        case ArithmeticTarget::B:
+                            registers.b = inc(registers.b);
+                            break;
+                        case ArithmeticTarget::C:
+                            registers.c = inc(registers.c);
+                            break;
+                        case ArithmeticTarget::D:
+                            registers.d = inc(registers.d);
+                            break;
+                        case ArithmeticTarget::E:
+                            registers.e = inc(registers.e);
+                            break;
+                        case ArithmeticTarget::H:
+                            registers.h = inc(registers.h);
+                            break;
+                        case ArithmeticTarget::L:
+                            registers.l = inc(registers.l);
+                            break;
+                    }
+
+                    break;
+                }
+
                 default:
                     // TODO: support more instructions
                     break;
@@ -384,6 +413,17 @@ class CPU {
             registers.f.subtract = false;
             registers.f.carry = false;
             registers.f.half_carry = false;
+
+            return result;
+        }
+
+        uint8_t inc(uint8_t value) {
+            uint8_t result = value + 1;
+
+            registers.f.zero = result == 0;
+            registers.f.subtract = false;
+            registers.f.carry = registers.f.carry; // INC doesnt affect the carry flag, it's left alone
+            registers.f.half_carry = (value & 0xF) + (1 & 0xF) > 0xF;
 
             return result;
         }

--- a/include/cpu.hpp
+++ b/include/cpu.hpp
@@ -8,7 +8,7 @@ enum class ArithmeticTarget {
 
 enum class InstructionType {
     ADD, ADC, SUB, SBC, AND,
-    OR, XOR
+    OR, XOR, CP
 };
 
 struct Instruction {
@@ -260,6 +260,39 @@ class CPU {
 
                     uint8_t new_value = bitwise_xor(value);
                     registers.a = new_value;
+
+                    break;
+                }
+
+                // CP Instruction subtracts specfified register contents from register A but doesnt store the result
+                case InstructionType::CP: {
+                    uint8_t value = 0;
+
+                    switch (instruction.target) {
+                        case ArithmeticTarget::A:
+                            value = registers.a;
+                            break;
+                        case ArithmeticTarget::B:
+                            value = registers.b;
+                            break;
+                        case ArithmeticTarget::C:
+                            value = registers.c;
+                            break;
+                        case ArithmeticTarget::D:
+                            value = registers.d;
+                            break;
+                        case ArithmeticTarget::E:
+                            value = registers.e;
+                            break;
+                        case ArithmeticTarget::H:
+                            value = registers.h;
+                            break;
+                        case ArithmeticTarget::L:
+                            value = registers.l;
+                            break;
+                    }
+
+                    uint8_t new_value = sub(value);
 
                     break;
                 }

--- a/include/cpu.hpp
+++ b/include/cpu.hpp
@@ -7,7 +7,7 @@ enum class ArithmeticTarget {
 };
 
 enum class InstructionType {
-    ADD, ADC, SUB
+    ADD, ADC, SUB, SBC
 };
 
 struct Instruction {
@@ -127,6 +127,40 @@ class CPU {
                     break;
                 }
 
+                // SBC Instruction substracts specified register contents + carry flag from register A
+                case InstructionType::SBC: {
+                    uint8_t value = 0;
+
+                    switch (instruction.target) {
+                        case ArithmeticTarget::A:
+                            value = registers.a;
+                            break;
+                        case ArithmeticTarget::B:
+                            value = registers.b;
+                            break;
+                        case ArithmeticTarget::C:
+                            value = registers.c;
+                            break;
+                        case ArithmeticTarget::D:
+                            value = registers.d;
+                            break;
+                        case ArithmeticTarget::E:
+                            value = registers.e;
+                            break;
+                        case ArithmeticTarget::H:
+                            value = registers.h;
+                            break;
+                        case ArithmeticTarget::L:
+                            value = registers.l;
+                            break;
+                    }
+
+                    uint8_t new_value = sbc(value);
+                    registers.a = new_value;
+
+                    break;
+                }
+
                 default:
                     // TODO: support more instructions
                     break;
@@ -169,6 +203,18 @@ class CPU {
             registers.f.subtract = true;
             registers.f.carry = underflowed;
             registers.f.half_carry = (value & 0xF) > (registers.a & 0xF);
+
+            return result;
+        }
+
+        uint8_t sbc(uint8_t value) {
+            uint8_t result = registers.a - (value + registers.f.carry);
+            bool underflowed = (value + registers.f.carry) > registers.a;
+
+            registers.f.zero = result == 0;
+            registers.f.subtract = true;
+            registers.f.carry = underflowed;
+            registers.f.half_carry = ((value + registers.f.carry) & 0xF) > (registers.a & 0xF);
 
             return result;
         }

--- a/include/cpu.hpp
+++ b/include/cpu.hpp
@@ -8,7 +8,7 @@ enum class ArithmeticTarget {
 
 enum class InstructionType {
     ADD, ADC, SUB, SBC, AND,
-    OR
+    OR, XOR
 };
 
 struct Instruction {
@@ -196,7 +196,7 @@ class CPU {
                     break;
                 }
 
-                // AND Instruction performs bitwise OR operation using specified register contents with register A
+                // OR Instruction performs bitwise OR operation using specified register contents with register A
                 case InstructionType::OR: {
                     uint8_t value = 0;
 
@@ -225,6 +225,40 @@ class CPU {
                     }
 
                     uint8_t new_value = bitwise_or(value);
+                    registers.a = new_value;
+
+                    break;
+                }
+
+                // XOR Instruction performs bitwise XOR operation using specified register contents with register A
+                case InstructionType::XOR: {
+                    uint8_t value = 0;
+
+                    switch (instruction.target) {
+                        case ArithmeticTarget::A:
+                            value = registers.a;
+                            break;
+                        case ArithmeticTarget::B:
+                            value = registers.b;
+                            break;
+                        case ArithmeticTarget::C:
+                            value = registers.c;
+                            break;
+                        case ArithmeticTarget::D:
+                            value = registers.d;
+                            break;
+                        case ArithmeticTarget::E:
+                            value = registers.e;
+                            break;
+                        case ArithmeticTarget::H:
+                            value = registers.h;
+                            break;
+                        case ArithmeticTarget::L:
+                            value = registers.l;
+                            break;
+                    }
+
+                    uint8_t new_value = bitwise_xor(value);
                     registers.a = new_value;
 
                     break;
@@ -301,6 +335,17 @@ class CPU {
 
         uint8_t bitwise_or(uint8_t value) {
             uint8_t result = registers.a & value;
+
+            registers.f.zero = result == 0;
+            registers.f.subtract = false;
+            registers.f.carry = false;
+            registers.f.half_carry = false;
+
+            return result;
+        }
+
+        uint8_t bitwise_xor(uint8_t value) {
+            uint8_t result = registers.a ^ value;
 
             registers.f.zero = result == 0;
             registers.f.subtract = false;

--- a/tests/cpu_tests.cpp
+++ b/tests/cpu_tests.cpp
@@ -349,3 +349,50 @@ TEST_CASE("XOR Unit Tests", "[cpu][8-bit][xor]") {
         REQUIRE(c2.registers.f.half_carry == false);
     }
 }
+
+TEST_CASE("CP Unit Tests", "[cpu][8-bit][cp]") {
+    Instruction instruct;
+    instruct.type = InstructionType::CP;
+    instruct.target = ArithmeticTarget::B;
+
+    SECTION ("CP w/o Overflow") {
+        CPU c1;
+
+        c1.registers.a = 2;
+        c1.registers.b = 1;
+
+        c1.execute(instruct);
+
+        REQUIRE(c1.registers.f.zero == false);
+        REQUIRE(c1.registers.f.subtract == true);
+        REQUIRE(c1.registers.f.carry == false);
+        REQUIRE(c1.registers.f.half_carry == false);
+    }
+
+    SECTION ("CP w Underflow") {
+        CPU c2;
+
+        c2.registers.a = 1;
+        c2.registers.b = 2;
+
+        c2.execute(instruct);
+
+        REQUIRE(c2.registers.f.zero == false);
+        REQUIRE(c2.registers.f.subtract == true);
+        REQUIRE(c2.registers.f.carry == true);
+        REQUIRE(c2.registers.f.half_carry == true);
+    }
+
+    SECTION ("CP to 0") {
+        CPU c3;
+        c3.registers.a = 1;
+        c3.registers.b = 1;
+
+        c3.execute(instruct);
+
+        REQUIRE(c3.registers.f.zero == true);
+        REQUIRE(c3.registers.f.subtract == true);
+        REQUIRE(c3.registers.f.carry == false);
+        REQUIRE(c3.registers.f.half_carry == false);
+    }
+}

--- a/tests/cpu_tests.cpp
+++ b/tests/cpu_tests.cpp
@@ -203,3 +203,41 @@ TEST_CASE("SUB Unit Tests", "[cpu][8-bit][sub]") {
         REQUIRE(c3.registers.f.half_carry == false);
     }
 }
+
+TEST_CASE("SBC Unit Tests", "[cpu][8-bit][sbc]") {
+    Instruction instruct;
+    instruct.type = InstructionType::SBC;
+    instruct.target = ArithmeticTarget::B;
+
+    SECTION ("SBC w/o Overflow - No Carry") {
+        CPU c1;
+
+        c1.registers.a = 2;
+        c1.registers.b = 1;
+        c1.registers.f.carry = 0;
+
+        c1.execute(instruct);
+
+        REQUIRE(c1.registers.a == 1);
+        REQUIRE(c1.registers.f.zero == false);
+        REQUIRE(c1.registers.f.subtract == true);
+        REQUIRE(c1.registers.f.carry == false);
+        REQUIRE(c1.registers.f.half_carry == false);
+    }
+
+    SECTION ("SBC w/o Overflow - w/ Carry") {
+        CPU c2;
+
+        c2.registers.a = 2;
+        c2.registers.b = 1;
+        c2.registers.f.carry = 1;
+
+        c2.execute(instruct);
+
+        REQUIRE(c2.registers.a == 0);
+        REQUIRE(c2.registers.f.zero == true);
+        REQUIRE(c2.registers.f.subtract == true);
+        REQUIRE(c2.registers.f.carry == false);
+        REQUIRE(c2.registers.f.half_carry == false);
+    }
+}

--- a/tests/cpu_tests.cpp
+++ b/tests/cpu_tests.cpp
@@ -566,3 +566,152 @@ TEST_CASE("INC Unit Tests", "[cpu][8-bit][inc]") {
         REQUIRE(c.registers.f.half_carry == true);
     }
 }
+
+TEST_CASE("DEC Unit Tests", "[cpu][8-bit][dec]") {
+    Instruction instruct;
+    instruct.type = InstructionType::DEC;
+
+    SECTION ("DEC Register A") {
+        instruct.target = ArithmeticTarget::A;
+
+        CPU c;
+
+        c.registers.a = 2;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.a == 1);
+        REQUIRE(c.registers.f.zero == false);
+        REQUIRE(c.registers.f.subtract == true);
+        REQUIRE(c.registers.f.carry == false);
+        REQUIRE(c.registers.f.half_carry == false);
+    }
+
+    SECTION ("DEC Register B") {
+        instruct.target = ArithmeticTarget::B;
+
+        CPU c;
+
+        c.registers.b = 2;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.b == 1);
+        REQUIRE(c.registers.f.zero == false);
+        REQUIRE(c.registers.f.subtract == true);
+        REQUIRE(c.registers.f.carry == false);
+        REQUIRE(c.registers.f.half_carry == false);
+    }
+
+    SECTION ("DEC Register C") {
+        instruct.target = ArithmeticTarget::C;
+
+        CPU c;
+
+        c.registers.c = 2;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.c == 1);
+        REQUIRE(c.registers.f.zero == false);
+        REQUIRE(c.registers.f.subtract == true);
+        REQUIRE(c.registers.f.carry == false);
+        REQUIRE(c.registers.f.half_carry == false);
+    }
+
+    SECTION ("DEC Register D") {
+        instruct.target = ArithmeticTarget::D;
+
+        CPU c;
+
+        c.registers.d = 2;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.d == 1);
+        REQUIRE(c.registers.f.zero == false);
+        REQUIRE(c.registers.f.subtract == true);
+        REQUIRE(c.registers.f.carry == false);
+        REQUIRE(c.registers.f.half_carry == false);
+    }
+
+    SECTION ("DEC Register E") {
+        instruct.target = ArithmeticTarget::E;
+
+        CPU c;
+
+        c.registers.e = 2;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.e == 1);
+        REQUIRE(c.registers.f.zero == false);
+        REQUIRE(c.registers.f.subtract == true);
+        REQUIRE(c.registers.f.carry == false);
+        REQUIRE(c.registers.f.half_carry == false);
+    }
+
+    SECTION ("DEC Register H") {
+        instruct.target = ArithmeticTarget::H;
+
+        CPU c;
+
+        c.registers.h = 2;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.h == 1);
+        REQUIRE(c.registers.f.zero == false);
+        REQUIRE(c.registers.f.subtract == true);
+        REQUIRE(c.registers.f.carry == false);
+        REQUIRE(c.registers.f.half_carry == false);
+    }
+
+    SECTION ("DEC Register L") {
+        instruct.target = ArithmeticTarget::L;
+
+        CPU c;
+
+        c.registers.l = 2;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.l == 1);
+        REQUIRE(c.registers.f.zero == false);
+        REQUIRE(c.registers.f.subtract == true);
+        REQUIRE(c.registers.f.carry == false);
+        REQUIRE(c.registers.f.half_carry == false);
+    }
+
+    SECTION ("DEC - Decrementing 0") {
+        instruct.target = ArithmeticTarget::B;
+
+        CPU c;
+
+        c.registers.b = 0;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.b == 255);
+        REQUIRE(c.registers.f.zero == false);
+        REQUIRE(c.registers.f.subtract == true);
+        REQUIRE(c.registers.f.carry == false);
+        REQUIRE(c.registers.f.half_carry == true);
+    }
+
+    SECTION ("DEC - Decrementing 1") {
+        instruct.target = ArithmeticTarget::B;
+
+        CPU c;
+
+        c.registers.b = 1;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.b == 0);
+        REQUIRE(c.registers.f.zero == true);
+        REQUIRE(c.registers.f.subtract == true);
+        REQUIRE(c.registers.f.carry == false);
+        REQUIRE(c.registers.f.half_carry == false);
+    }
+}

--- a/tests/cpu_tests.cpp
+++ b/tests/cpu_tests.cpp
@@ -277,3 +277,39 @@ TEST_CASE("AND Unit Tests", "[cpu][8-bit][and]") {
         REQUIRE(c2.registers.f.half_carry == true);
     }
 }
+
+TEST_CASE("OR Unit Tests", "[cpu][8-bit][or]") {
+    Instruction instruct;
+    instruct.type = InstructionType::OR;
+    instruct.target = ArithmeticTarget::B;
+
+    SECTION ("OR - No Zero") {
+        CPU c1;
+
+        c1.registers.a = 1;
+        c1.registers.b = 1;
+
+        c1.execute(instruct);
+
+        REQUIRE(c1.registers.a == 1);
+        REQUIRE(c1.registers.f.zero == false);
+        REQUIRE(c1.registers.f.subtract == false);
+        REQUIRE(c1.registers.f.carry == false);
+        REQUIRE(c1.registers.f.half_carry == false);
+    }
+
+    SECTION ("OR - Zero") {
+        CPU c2;
+
+        c2.registers.a = 0;
+        c2.registers.b = 0;
+
+        c2.execute(instruct);
+
+        REQUIRE(c2.registers.a == 0);
+        REQUIRE(c2.registers.f.zero == true);
+        REQUIRE(c2.registers.f.subtract == false);
+        REQUIRE(c2.registers.f.carry == false);
+        REQUIRE(c2.registers.f.half_carry == false);
+    }
+}

--- a/tests/cpu_tests.cpp
+++ b/tests/cpu_tests.cpp
@@ -241,3 +241,39 @@ TEST_CASE("SBC Unit Tests", "[cpu][8-bit][sbc]") {
         REQUIRE(c2.registers.f.half_carry == false);
     }
 }
+
+TEST_CASE("AND Unit Tests", "[cpu][8-bit][and]") {
+    Instruction instruct;
+    instruct.type = InstructionType::AND;
+    instruct.target = ArithmeticTarget::B;
+
+    SECTION ("AND - No Zero") {
+        CPU c1;
+
+        c1.registers.a = 1;
+        c1.registers.b = 1;
+
+        c1.execute(instruct);
+
+        REQUIRE(c1.registers.a == 1);
+        REQUIRE(c1.registers.f.zero == false);
+        REQUIRE(c1.registers.f.subtract == false);
+        REQUIRE(c1.registers.f.carry == false);
+        REQUIRE(c1.registers.f.half_carry == true);
+    }
+
+    SECTION ("AND - w/ Zero") {
+        CPU c2;
+
+        c2.registers.a = 100;
+        c2.registers.b = 0;
+
+        c2.execute(instruct);
+
+        REQUIRE(c2.registers.a == 0);
+        REQUIRE(c2.registers.f.zero == true);
+        REQUIRE(c2.registers.f.subtract == false);
+        REQUIRE(c2.registers.f.carry == false);
+        REQUIRE(c2.registers.f.half_carry == true);
+    }
+}

--- a/tests/cpu_tests.cpp
+++ b/tests/cpu_tests.cpp
@@ -363,6 +363,7 @@ TEST_CASE("CP Unit Tests", "[cpu][8-bit][cp]") {
 
         c1.execute(instruct);
 
+        REQUIRE(c1.registers.a == 2);
         REQUIRE(c1.registers.f.zero == false);
         REQUIRE(c1.registers.f.subtract == true);
         REQUIRE(c1.registers.f.carry == false);
@@ -377,6 +378,7 @@ TEST_CASE("CP Unit Tests", "[cpu][8-bit][cp]") {
 
         c2.execute(instruct);
 
+        REQUIRE(c2.registers.a == 1);
         REQUIRE(c2.registers.f.zero == false);
         REQUIRE(c2.registers.f.subtract == true);
         REQUIRE(c2.registers.f.carry == true);
@@ -390,9 +392,177 @@ TEST_CASE("CP Unit Tests", "[cpu][8-bit][cp]") {
 
         c3.execute(instruct);
 
+        REQUIRE(c3.registers.a == 1);
         REQUIRE(c3.registers.f.zero == true);
         REQUIRE(c3.registers.f.subtract == true);
         REQUIRE(c3.registers.f.carry == false);
         REQUIRE(c3.registers.f.half_carry == false);
+    }
+}
+
+TEST_CASE("INC Unit Tests", "[cpu][8-bit][inc]") {
+    Instruction instruct;
+    instruct.type = InstructionType::INC;
+
+    SECTION ("INC Register A") {
+        instruct.target = ArithmeticTarget::A;
+
+        CPU c;
+
+        c.registers.a = 1;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.a == 2);
+        REQUIRE(c.registers.f.zero == false);
+        REQUIRE(c.registers.f.subtract == false);
+        REQUIRE(c.registers.f.carry == false);
+        REQUIRE(c.registers.f.half_carry == false);
+    }
+
+    SECTION ("INC Register B") {
+        instruct.target = ArithmeticTarget::B;
+
+        CPU c;
+
+        c.registers.b = 1;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.b == 2);
+        REQUIRE(c.registers.f.zero == false);
+        REQUIRE(c.registers.f.subtract == false);
+        REQUIRE(c.registers.f.carry == false);
+        REQUIRE(c.registers.f.half_carry == false);
+    }
+
+    SECTION ("INC Register C") {
+        instruct.target = ArithmeticTarget::C;
+
+        CPU c;
+
+        c.registers.c = 1;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.c == 2);
+        REQUIRE(c.registers.f.zero == false);
+        REQUIRE(c.registers.f.subtract == false);
+        REQUIRE(c.registers.f.carry == false);
+        REQUIRE(c.registers.f.half_carry == false);
+    }
+
+    SECTION ("INC Register D") {
+        instruct.target = ArithmeticTarget::D;
+
+        CPU c;
+
+        c.registers.d = 1;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.d == 2);
+        REQUIRE(c.registers.f.zero == false);
+        REQUIRE(c.registers.f.subtract == false);
+        REQUIRE(c.registers.f.carry == false);
+        REQUIRE(c.registers.f.half_carry == false);
+    }
+
+    SECTION ("INC Register E") {
+        instruct.target = ArithmeticTarget::E;
+
+        CPU c;
+
+        c.registers.e = 1;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.e == 2);
+        REQUIRE(c.registers.f.zero == false);
+        REQUIRE(c.registers.f.subtract == false);
+        REQUIRE(c.registers.f.carry == false);
+        REQUIRE(c.registers.f.half_carry == false);
+    }
+
+    SECTION ("INC Register H") {
+        instruct.target = ArithmeticTarget::H;
+
+        CPU c;
+
+        c.registers.h = 1;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.h == 2);
+        REQUIRE(c.registers.f.zero == false);
+        REQUIRE(c.registers.f.subtract == false);
+        REQUIRE(c.registers.f.carry == false);
+        REQUIRE(c.registers.f.half_carry == false);
+    }
+
+    SECTION ("INC Register L") {
+        instruct.target = ArithmeticTarget::L;
+
+        CPU c;
+
+        c.registers.l = 1;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.l == 2);
+        REQUIRE(c.registers.f.zero == false);
+        REQUIRE(c.registers.f.subtract == false);
+        REQUIRE(c.registers.f.carry == false);
+        REQUIRE(c.registers.f.half_carry == false);
+    }
+
+    SECTION ("INC - Overflow - Carry Set to False") {
+        instruct.target = ArithmeticTarget::B;
+
+        CPU c;
+
+        c.registers.b = 255;
+        c.registers.f.carry = false;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.b == 0);
+        REQUIRE(c.registers.f.zero == true);
+        REQUIRE(c.registers.f.subtract == false);
+        REQUIRE(c.registers.f.carry == false);
+        REQUIRE(c.registers.f.half_carry == true);
+    }
+
+    SECTION ("INC - Overflow - Carry Set to True") {
+        instruct.target = ArithmeticTarget::B;
+
+        CPU c;
+
+        c.registers.b = 255;
+        c.registers.f.carry = true;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.b == 0);
+        REQUIRE(c.registers.f.zero == true);
+        REQUIRE(c.registers.f.subtract == false);
+        REQUIRE(c.registers.f.carry == true);
+        REQUIRE(c.registers.f.half_carry == true);
+    }
+
+    SECTION ("INC - Half Carry") {
+        instruct.target = ArithmeticTarget::B;
+
+        CPU c;
+
+        c.registers.b = 15;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.b == 16);
+        REQUIRE(c.registers.f.zero == false);
+        REQUIRE(c.registers.f.subtract == false);
+        REQUIRE(c.registers.f.carry == false);
+        REQUIRE(c.registers.f.half_carry == true);
     }
 }

--- a/tests/cpu_tests.cpp
+++ b/tests/cpu_tests.cpp
@@ -153,3 +153,53 @@ TEST_CASE("ADC Unit Tests", "[cpu][8-bit][adc]") {
         REQUIRE(c4.registers.f.half_carry == false);
     }
 }
+
+TEST_CASE("SUB Unit Tests", "[cpu][8-bit][sub]") {
+    Instruction instruct;
+    instruct.type = InstructionType::SUB;
+    instruct.target = ArithmeticTarget::B;
+
+    SECTION ("SUB w/o Overflow") {
+        CPU c1;
+
+        c1.registers.a = 2;
+        c1.registers.b = 1;
+
+        c1.execute(instruct);
+
+        REQUIRE(c1.registers.a == 1);
+        REQUIRE(c1.registers.f.zero == false);
+        REQUIRE(c1.registers.f.subtract == true);
+        REQUIRE(c1.registers.f.carry == false);
+        REQUIRE(c1.registers.f.half_carry == false);
+    }
+
+    SECTION ("SUB w Underflow") {
+        CPU c2;
+
+        c2.registers.a = 1;
+        c2.registers.b = 2;
+
+        c2.execute(instruct);
+
+        REQUIRE(c2.registers.a == 255);
+        REQUIRE(c2.registers.f.zero == false);
+        REQUIRE(c2.registers.f.subtract == true);
+        REQUIRE(c2.registers.f.carry == true);
+        REQUIRE(c2.registers.f.half_carry == true);
+    }
+
+    SECTION ("SUB to 0") {
+        CPU c3;
+        c3.registers.a = 1;
+        c3.registers.b = 1;
+
+        c3.execute(instruct);
+
+        REQUIRE(c3.registers.a == 0);
+        REQUIRE(c3.registers.f.zero == true);
+        REQUIRE(c3.registers.f.subtract == true);
+        REQUIRE(c3.registers.f.carry == false);
+        REQUIRE(c3.registers.f.half_carry == false);
+    }
+}

--- a/tests/cpu_tests.cpp
+++ b/tests/cpu_tests.cpp
@@ -313,3 +313,39 @@ TEST_CASE("OR Unit Tests", "[cpu][8-bit][or]") {
         REQUIRE(c2.registers.f.half_carry == false);
     }
 }
+
+TEST_CASE("XOR Unit Tests", "[cpu][8-bit][xor]") {
+    Instruction instruct;
+    instruct.type = InstructionType::XOR;
+    instruct.target = ArithmeticTarget::B;
+
+    SECTION ("XOR 1") {
+        CPU c1;
+
+        c1.registers.a = 1;
+        c1.registers.b = 2;
+
+        c1.execute(instruct);
+
+        REQUIRE(c1.registers.a == 3);
+        REQUIRE(c1.registers.f.zero == false);
+        REQUIRE(c1.registers.f.subtract == false);
+        REQUIRE(c1.registers.f.carry == false);
+        REQUIRE(c1.registers.f.half_carry == false);
+    }
+
+    SECTION ("XOR 2") {
+        CPU c2;
+
+        c2.registers.a = 0;
+        c2.registers.b = 0;
+
+        c2.execute(instruct);
+
+        REQUIRE(c2.registers.a == 0);
+        REQUIRE(c2.registers.f.zero == true);
+        REQUIRE(c2.registers.f.subtract == false);
+        REQUIRE(c2.registers.f.carry == false);
+        REQUIRE(c2.registers.f.half_carry == false);
+    }
+}


### PR DESCRIPTION
# Issue
https://github.com/Sam-Coburn/gameboy_emulator/issues/1

# Changes
- Implemented the following CPU instructions and also created unit test cases for each:

1. SUB
2. SBC
3. AND
4. OR
5. XOR
6. CP
7. INC
8. DEC

# Test Results
<img width="692" height="497" alt="Screenshot 2026-04-15 at 10 20 26 AM" src="https://github.com/user-attachments/assets/88508d0c-864e-48e0-a919-64a22980bfde" />
The code compiles successfully and all unit test cases pass successfully