### PR TITLE
Implementing Miscellaneous Instructions in CPU Class

### DIFF
--- a/include/cpu.hpp
+++ b/include/cpu.hpp
@@ -11,7 +11,7 @@ enum class ArithmeticTarget {
 enum class InstructionType {
     ADD, ADC, SUB, SBC, AND,
     OR, XOR, CP, INC, DEC,
-    SWAP
+    SWAP, SCF, CCF
 };
 
 struct Instruction {
@@ -383,6 +383,33 @@ class CPU {
                             registers.l = swap(registers.l);
                             break;
                     }
+
+                    break;
+                }
+
+                // SCF Instruction sets the carry flag, i.e. changes its value to True
+                case InstructionType::SCF: {
+                    registers.f.carry = true;
+
+                    registers.f.zero = registers.f.zero; // SCF flag leaves zero flag unaffected
+                    registers.f.subtract = false;
+                    registers.f.half_carry = false;
+
+                    break;
+                }
+
+                // CCF Instruction toggles the carry flag, e.g. C = True --> False, C = False --> True
+                case InstructionType::CCF: {
+                    if (registers.f.carry) {
+                        registers.f.carry = false;
+                    }
+                    else {
+                        registers.f.carry = true;
+                    }
+
+                    registers.f.zero = registers.f.zero; // CCF flag leaves zero flag unaffected
+                    registers.f.subtract = false;
+                    registers.f.half_carry = false;
 
                     break;
                 }

--- a/include/cpu.hpp
+++ b/include/cpu.hpp
@@ -11,7 +11,7 @@ enum class ArithmeticTarget {
 enum class InstructionType {
     ADD, ADC, SUB, SBC, AND,
     OR, XOR, CP, INC, DEC,
-    SWAP, SCF, CCF
+    SWAP, SCF, CCF, CPL
 };
 
 struct Instruction {
@@ -391,7 +391,7 @@ class CPU {
                 case InstructionType::SCF: {
                     registers.f.carry = true;
 
-                    registers.f.zero = registers.f.zero; // SCF flag leaves zero flag unaffected
+                    registers.f.zero = registers.f.zero; // SCF instruction leaves zero flag unaffected
                     registers.f.subtract = false;
                     registers.f.half_carry = false;
 
@@ -407,9 +407,21 @@ class CPU {
                         registers.f.carry = true;
                     }
 
-                    registers.f.zero = registers.f.zero; // CCF flag leaves zero flag unaffected
+                    registers.f.zero = registers.f.zero; // CCF instruction leaves zero flag unaffected
                     registers.f.subtract = false;
                     registers.f.half_carry = false;
+
+                    break;
+                }
+
+                // CPL Instruction toggles every bit of register A
+                case InstructionType::CPL: {
+                    registers.a = ~registers.a;
+
+                    registers.f.zero = registers.f.zero; // CPL instruction leaves zero flag unaffected
+                    registers.f.subtract = true;
+                    registers.f.carry = registers.f.carry; // CPL instruction leaves carry flag unaffected
+                    registers.f.half_carry = true;
 
                     break;
                 }

--- a/include/cpu.hpp
+++ b/include/cpu.hpp
@@ -1,6 +1,8 @@
 #include <registers.hpp>
 
 #include <stdint.h>
+#include <iostream>
+#include <bitset>
 
 enum class ArithmeticTarget {
     A, B, C, D, E, H, L
@@ -8,7 +10,8 @@ enum class ArithmeticTarget {
 
 enum class InstructionType {
     ADD, ADC, SUB, SBC, AND,
-    OR, XOR, CP, INC, DEC
+    OR, XOR, CP, INC, DEC,
+    SWAP
 };
 
 struct Instruction {
@@ -355,6 +358,35 @@ class CPU {
                     break;
                 }
 
+                // SWAP Instruction swaps the values of the upper and lower nibbles of the target register
+                case InstructionType::SWAP: {
+                    switch (instruction.target) {
+                        case ArithmeticTarget::A:
+                            registers.a = swap(registers.a);
+                            break;
+                        case ArithmeticTarget::B:
+                            registers.b = swap(registers.b);
+                            break;
+                        case ArithmeticTarget::C:
+                            registers.c = swap(registers.c);
+                            break;
+                        case ArithmeticTarget::D:
+                            registers.d = swap(registers.d);
+                            break;
+                        case ArithmeticTarget::E:
+                            registers.e = swap(registers.e);
+                            break;
+                        case ArithmeticTarget::H:
+                            registers.h = swap(registers.h);
+                            break;
+                        case ArithmeticTarget::L:
+                            registers.l = swap(registers.l);
+                            break;
+                    }
+
+                    break;
+                }
+
                 default:
                     // TODO: support more instructions
                     break;
@@ -464,6 +496,19 @@ class CPU {
             registers.f.subtract = true;
             registers.f.carry = registers.f.carry; // DEC doesnt affect the carry flag, it's left alone
             registers.f.half_carry = (1 & 0xF) > (value & 0xF);
+
+            return result;
+        }
+
+        uint8_t swap(uint8_t value) {
+            uint8_t upper_nibble = value & 0b11110000;
+            uint8_t lower_nibble = value & 0b00001111;
+            uint8_t result = (lower_nibble << 4) | (upper_nibble >> 4);
+
+            registers.f.zero = result == 0;
+            registers.f.subtract = false;
+            registers.f.carry = false;
+            registers.f.half_carry = false;
 
             return result;
         }

--- a/tests/cpu_tests.cpp
+++ b/tests/cpu_tests.cpp
@@ -716,7 +716,7 @@ TEST_CASE("DEC Unit Tests", "[cpu][8-bit][dec]") {
     }
 }
 
-TEST_CASE("SWAP Unit Tests", "[cpu][8-bit][swap]") {
+TEST_CASE("SWAP Unit Tests", "[cpu][misc][swap]") {
     Instruction instruct;
     instruct.type = InstructionType::SWAP;
 
@@ -829,6 +829,102 @@ TEST_CASE("SWAP Unit Tests", "[cpu][8-bit][swap]") {
         REQUIRE(c.registers.f.zero == false);
         REQUIRE(c.registers.f.subtract == false);
         REQUIRE(c.registers.f.carry == false);
+        REQUIRE(c.registers.f.half_carry == false);
+    }
+}
+
+TEST_CASE("SCF Unit Tests", "[cpu][misc][scf]") {
+    Instruction instruct;
+    instruct.type = InstructionType::SCF;
+
+    SECTION ("Carry Flag is False") {
+        CPU c;
+
+        c.registers.f.carry = false;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.f.carry == true);
+
+        REQUIRE(c.registers.f.zero == false);
+        REQUIRE(c.registers.f.subtract == false);
+        REQUIRE(c.registers.f.half_carry == false);
+    }
+
+    SECTION ("Carry Flag is True") {
+        CPU c;
+
+        c.registers.f.carry = true;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.f.carry == true);
+
+        REQUIRE(c.registers.f.zero == false);
+        REQUIRE(c.registers.f.subtract == false);
+        REQUIRE(c.registers.f.half_carry == false);
+    }
+
+    SECTION ("Zero Flag is True") {
+        CPU c;
+
+        c.registers.f.carry = false;
+        c.registers.f.zero = true;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.f.carry == true);
+
+        REQUIRE(c.registers.f.zero == true);
+        REQUIRE(c.registers.f.subtract == false);
+        REQUIRE(c.registers.f.half_carry == false);
+    }
+}
+
+TEST_CASE("CCF Unit Tests", "[cpu][misc][ccf]") {
+    Instruction instruct;
+    instruct.type = InstructionType::CCF;
+
+    SECTION ("Carry Flag is False") {
+        CPU c;
+
+        c.registers.f.carry = false;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.f.carry == true);
+
+        REQUIRE(c.registers.f.zero == false);
+        REQUIRE(c.registers.f.subtract == false);
+        REQUIRE(c.registers.f.half_carry == false);
+    }
+
+    SECTION ("Carry Flag is True") {
+        CPU c;
+
+        c.registers.f.carry = true;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.f.carry == false);
+
+        REQUIRE(c.registers.f.zero == false);
+        REQUIRE(c.registers.f.subtract == false);
+        REQUIRE(c.registers.f.half_carry == false);
+    }
+
+    SECTION ("Zero Flag is True") {
+        CPU c;
+
+        c.registers.f.carry = true;
+        c.registers.f.zero = true;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.f.carry == false);
+
+        REQUIRE(c.registers.f.zero == true);
+        REQUIRE(c.registers.f.subtract == false);
         REQUIRE(c.registers.f.half_carry == false);
     }
 }

--- a/tests/cpu_tests.cpp
+++ b/tests/cpu_tests.cpp
@@ -715,3 +715,120 @@ TEST_CASE("DEC Unit Tests", "[cpu][8-bit][dec]") {
         REQUIRE(c.registers.f.half_carry == false);
     }
 }
+
+TEST_CASE("SWAP Unit Tests", "[cpu][8-bit][swap]") {
+    Instruction instruct;
+    instruct.type = InstructionType::SWAP;
+
+    SECTION ("SWAP Register A") {
+        instruct.target = ArithmeticTarget::A;
+
+        CPU c;
+
+        c.registers.a = 0b10100001;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.a == 0b00011010);
+        REQUIRE(c.registers.f.zero == false);
+        REQUIRE(c.registers.f.subtract == false);
+        REQUIRE(c.registers.f.carry == false);
+        REQUIRE(c.registers.f.half_carry == false);
+    }
+
+    SECTION ("SWAP Register B") {
+        instruct.target = ArithmeticTarget::B;
+
+        CPU c;
+
+        c.registers.b = 0b10100001;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.b == 0b00011010);
+        REQUIRE(c.registers.f.zero == false);
+        REQUIRE(c.registers.f.subtract == false);
+        REQUIRE(c.registers.f.carry == false);
+        REQUIRE(c.registers.f.half_carry == false);
+    }
+
+    SECTION ("SWAP Register C") {
+        instruct.target = ArithmeticTarget::C;
+
+        CPU c;
+
+        c.registers.c = 0b10100001;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.c == 0b00011010);
+        REQUIRE(c.registers.f.zero == false);
+        REQUIRE(c.registers.f.subtract == false);
+        REQUIRE(c.registers.f.carry == false);
+        REQUIRE(c.registers.f.half_carry == false);
+    }
+
+    SECTION ("SWAP Register D") {
+        instruct.target = ArithmeticTarget::D;
+
+        CPU c;
+
+        c.registers.d = 0b10100001;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.d == 0b00011010);
+        REQUIRE(c.registers.f.zero == false);
+        REQUIRE(c.registers.f.subtract == false);
+        REQUIRE(c.registers.f.carry == false);
+        REQUIRE(c.registers.f.half_carry == false);
+    }
+
+    SECTION ("SWAP Register E") {
+        instruct.target = ArithmeticTarget::E;
+
+        CPU c;
+
+        c.registers.e = 0b10100001;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.e == 0b00011010);
+        REQUIRE(c.registers.f.zero == false);
+        REQUIRE(c.registers.f.subtract == false);
+        REQUIRE(c.registers.f.carry == false);
+        REQUIRE(c.registers.f.half_carry == false);
+    }
+
+    SECTION ("SWAP Register H") {
+        instruct.target = ArithmeticTarget::H;
+
+        CPU c;
+
+        c.registers.h = 0b10100001;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.h == 0b00011010);
+        REQUIRE(c.registers.f.zero == false);
+        REQUIRE(c.registers.f.subtract == false);
+        REQUIRE(c.registers.f.carry == false);
+        REQUIRE(c.registers.f.half_carry == false);
+    }
+
+    SECTION ("SWAP Register L") {
+        instruct.target = ArithmeticTarget::L;
+
+        CPU c;
+
+        c.registers.l = 0b10100001;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.l == 0b00011010);
+        REQUIRE(c.registers.f.zero == false);
+        REQUIRE(c.registers.f.subtract == false);
+        REQUIRE(c.registers.f.carry == false);
+        REQUIRE(c.registers.f.half_carry == false);
+    }
+}

--- a/tests/cpu_tests.cpp
+++ b/tests/cpu_tests.cpp
@@ -928,3 +928,82 @@ TEST_CASE("CCF Unit Tests", "[cpu][misc][ccf]") {
         REQUIRE(c.registers.f.half_carry == false);
     }
 }
+
+TEST_CASE("CPL Unit Tests", "[cpu][misc][cpl]") {
+    Instruction instruct;
+    instruct.type = InstructionType::CPL;
+
+    SECTION ("CPL 1") {
+        CPU c;
+
+        c.registers.a = 0b11111111;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.a == 0b00000000);
+        REQUIRE(c.registers.f.zero == false);
+        REQUIRE(c.registers.f.subtract == true);
+        REQUIRE(c.registers.f.carry == false);
+        REQUIRE(c.registers.f.half_carry == true);
+    }
+
+    SECTION ("CPL 2") {
+        CPU c;
+
+        c.registers.a = 0b01010101;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.a == 0b10101010);
+        REQUIRE(c.registers.f.zero == false);
+        REQUIRE(c.registers.f.subtract == true);
+        REQUIRE(c.registers.f.carry == false);
+        REQUIRE(c.registers.f.half_carry == true);
+    }
+
+    SECTION ("CPL 3 - Zero Flag Set") {
+        CPU c;
+
+        c.registers.a = 0;
+        c.registers.f.zero = true;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.a == 255);
+        REQUIRE(c.registers.f.zero == true);
+        REQUIRE(c.registers.f.subtract == true);
+        REQUIRE(c.registers.f.carry == false);
+        REQUIRE(c.registers.f.half_carry == true);
+    }
+
+    SECTION ("CPL 4 - Carry Flag Set") {
+        CPU c;
+
+        c.registers.a = 0;
+        c.registers.f.carry = true;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.a == 255);
+        REQUIRE(c.registers.f.zero == false);
+        REQUIRE(c.registers.f.subtract == true);
+        REQUIRE(c.registers.f.carry == true);
+        REQUIRE(c.registers.f.half_carry == true);
+    }
+
+    SECTION ("CPL 5 - Zero and Carry Flag Set") {
+        CPU c;
+
+        c.registers.a = 0;
+        c.registers.f.zero = true;
+        c.registers.f.carry = true;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.a == 255);
+        REQUIRE(c.registers.f.zero == true);
+        REQUIRE(c.registers.f.subtract == true);
+        REQUIRE(c.registers.f.carry == true);
+        REQUIRE(c.registers.f.half_carry == true);
+    }
+}


### PR DESCRIPTION
# Issue
https://github.com/Sam-Coburn/gameboy_emulator/issues/4

# Changes
- Implemented the following CPU instructions and also created unit test cases for each:

1. SWAP
2. SCP
3. CCP
4. CPL

# Test Results
<img width="707" height="497" alt="Screenshot 2026-04-15 at 4 30 47 PM" src="https://github.com/user-attachments/assets/f36c9556-0850-44c4-931e-1092233b5b29" />
The code compiles successfully and all unit test cases pass successfully