### PR TITLE
Implementing Bit Opcode Instructions in CPU Class

### DIFF
--- a/include/cpu.hpp
+++ b/include/cpu.hpp
@@ -11,12 +11,13 @@ enum class ArithmeticTarget {
 enum class InstructionType {
     ADD, ADC, SUB, SBC, AND,
     OR, XOR, CP, INC, DEC,
-    SWAP, SCF, CCF, CPL
+    SWAP, SCF, CCF, CPL, BIT
 };
 
 struct Instruction {
     InstructionType type;
     ArithmeticTarget target;
+    uint8_t bit_index;
 };
 
 class CPU {
@@ -421,6 +422,45 @@ class CPU {
                     registers.f.zero = registers.f.zero; // CPL instruction leaves zero flag unaffected
                     registers.f.subtract = true;
                     registers.f.carry = registers.f.carry; // CPL instruction leaves carry flag unaffected
+                    registers.f.half_carry = true;
+
+                    break;
+                }
+
+                // BIT Instruction tests the bit value for the given register at the given bit index
+                case InstructionType::BIT: {
+                    uint8_t bit_index = instruction.bit_index;
+                    uint8_t value = 0;
+
+                    switch (instruction.target) {
+                        case ArithmeticTarget::A:
+                            value = registers.a;
+                            break;
+                        case ArithmeticTarget::B:
+                            value = registers.b;
+                            break;
+                        case ArithmeticTarget::C:
+                            value = registers.c;
+                            break;
+                        case ArithmeticTarget::D:
+                            value = registers.d;
+                            break;
+                        case ArithmeticTarget::E:
+                            value = registers.e;
+                            break;
+                        case ArithmeticTarget::H:
+                            value = registers.h;
+                            break;
+                        case ArithmeticTarget::L:
+                            value = registers.l;
+                            break;
+                    }
+
+                    uint8_t bit_value = (value >> bit_index) & (0b00000001);
+
+                    registers.f.zero = bit_value == 0;
+                    registers.f.subtract = false;
+                    registers.f.carry = registers.f.carry; // BIT instruction leaves carry flag unaffected
                     registers.f.half_carry = true;
 
                     break;

--- a/include/cpu.hpp
+++ b/include/cpu.hpp
@@ -11,7 +11,8 @@ enum class ArithmeticTarget {
 enum class InstructionType {
     ADD, ADC, SUB, SBC, AND,
     OR, XOR, CP, INC, DEC,
-    SWAP, SCF, CCF, CPL, BIT
+    SWAP, SCF, CCF, CPL, BIT,
+    SET
 };
 
 struct Instruction {
@@ -462,6 +463,37 @@ class CPU {
                     registers.f.subtract = false;
                     registers.f.carry = registers.f.carry; // BIT instruction leaves carry flag unaffected
                     registers.f.half_carry = true;
+
+                    break;
+                }
+
+                // SET Instruction sets the bit value for the given register at the given bit index to 1
+                case InstructionType::SET: {
+                    uint8_t bit_index = instruction.bit_index;
+
+                    switch (instruction.target) {
+                        case ArithmeticTarget::A:
+                            registers.a = registers.a | (1 << bit_index);
+                            break;
+                        case ArithmeticTarget::B:
+                            registers.b = registers.b | (1 << bit_index);
+                            break;
+                        case ArithmeticTarget::C:
+                            registers.c = registers.c | (1 << bit_index);
+                            break;
+                        case ArithmeticTarget::D:
+                            registers.d = registers.d | (1 << bit_index);
+                            break;
+                        case ArithmeticTarget::E:
+                            registers.e = registers.e | (1 << bit_index);
+                            break;
+                        case ArithmeticTarget::H:
+                            registers.h = registers.h | (1 << bit_index);
+                            break;
+                        case ArithmeticTarget::L:
+                            registers.l = registers.l | (1 << bit_index);
+                            break;
+                    }
 
                     break;
                 }

--- a/include/cpu.hpp
+++ b/include/cpu.hpp
@@ -12,7 +12,7 @@ enum class InstructionType {
     ADD, ADC, SUB, SBC, AND,
     OR, XOR, CP, INC, DEC,
     SWAP, SCF, CCF, CPL, BIT,
-    SET
+    SET, RESET
 };
 
 struct Instruction {
@@ -492,6 +492,37 @@ class CPU {
                             break;
                         case ArithmeticTarget::L:
                             registers.l = registers.l | (1 << bit_index);
+                            break;
+                    }
+
+                    break;
+                }
+
+                // RESET Instruction sets the bit value for the given register at the given bit index to 0
+                case InstructionType::RESET: {
+                    uint8_t bit_index = instruction.bit_index;
+
+                    switch (instruction.target) {
+                        case ArithmeticTarget::A:
+                            registers.a = registers.a & ~(1 << bit_index);
+                            break;
+                        case ArithmeticTarget::B:
+                            registers.b = registers.b & ~(1 << bit_index);
+                            break;
+                        case ArithmeticTarget::C:
+                            registers.c = registers.c & ~(1 << bit_index);
+                            break;
+                        case ArithmeticTarget::D:
+                            registers.d = registers.d & ~(1 << bit_index);
+                            break;
+                        case ArithmeticTarget::E:
+                            registers.e = registers.e & ~(1 << bit_index);
+                            break;
+                        case ArithmeticTarget::H:
+                            registers.h = registers.h & ~(1 << bit_index);
+                            break;
+                        case ArithmeticTarget::L:
+                            registers.l = registers.l & ~(1 << bit_index);
                             break;
                     }
 

--- a/tests/cpu_tests.cpp
+++ b/tests/cpu_tests.cpp
@@ -1163,3 +1163,116 @@ TEST_CASE("BIT Unit Tests", "[cpu][bit_opcode][bit]") {
         REQUIRE(c.registers.f.half_carry == true);
     }
 }
+
+TEST_CASE("SET Unit Tests", "[cpu][bit_opcode][set]") {
+    Instruction instruct;
+    instruct.type = InstructionType::SET;
+
+    SECTION ("SET 1") {
+        CPU c;
+        instruct.target = ArithmeticTarget::A;
+        instruct.bit_index = 3;
+
+        c.registers.a = 0;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.a == 0b00001000);
+    }
+
+    SECTION ("SET 2") {
+        CPU c;
+        instruct.target = ArithmeticTarget::A;
+        instruct.bit_index = 7;
+
+        c.registers.a = 0;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.a == 0b10000000);
+    }
+
+    SECTION ("SET 3") {
+        CPU c;
+        instruct.target = ArithmeticTarget::A;
+        instruct.bit_index = 0;
+
+        c.registers.a = 0;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.a == 0b00000001);
+    }
+
+    SECTION ("SET 4") {
+        CPU c;
+        instruct.target = ArithmeticTarget::B;
+        instruct.bit_index = 3;
+
+        c.registers.b = 0;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.b == 0b00001000);
+    }
+
+    SECTION ("SET 5") {
+        CPU c;
+        instruct.target = ArithmeticTarget::C;
+        instruct.bit_index = 3;
+
+        c.registers.c = 0;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.c == 0b00001000);
+    }
+
+    SECTION ("SET 6") {
+        CPU c;
+        instruct.target = ArithmeticTarget::D;
+        instruct.bit_index = 3;
+
+        c.registers.d = 0;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.d == 0b00001000);
+    }
+
+    SECTION ("SET 7") {
+        CPU c;
+        instruct.target = ArithmeticTarget::E;
+        instruct.bit_index = 3;
+
+        c.registers.e = 0;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.e == 0b00001000);
+    }
+
+    SECTION ("SET 8") {
+        CPU c;
+        instruct.target = ArithmeticTarget::H;
+        instruct.bit_index = 3;
+
+        c.registers.h = 0;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.h == 0b00001000);
+    }
+
+    SECTION ("SET 9") {
+        CPU c;
+        instruct.target = ArithmeticTarget::L;
+        instruct.bit_index = 3;
+
+        c.registers.l = 0;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.l == 0b00001000);
+    }
+}

--- a/tests/cpu_tests.cpp
+++ b/tests/cpu_tests.cpp
@@ -1276,3 +1276,116 @@ TEST_CASE("SET Unit Tests", "[cpu][bit_opcode][set]") {
         REQUIRE(c.registers.l == 0b00001000);
     }
 }
+
+TEST_CASE("RESET Unit Tests", "[cpu][bit_opcode][reset]") {
+    Instruction instruct;
+    instruct.type = InstructionType::RESET;
+
+    SECTION ("RESET 1") {
+        CPU c;
+        instruct.target = ArithmeticTarget::A;
+        instruct.bit_index = 3;
+
+        c.registers.a = 255;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.a == 0b11110111);
+    }
+
+    SECTION ("RESET 2") {
+        CPU c;
+        instruct.target = ArithmeticTarget::A;
+        instruct.bit_index = 7;
+
+        c.registers.a = 255;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.a == 0b01111111);
+    }
+
+    SECTION ("RESET 3") {
+        CPU c;
+        instruct.target = ArithmeticTarget::A;
+        instruct.bit_index = 0;
+
+        c.registers.a = 255;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.a == 0b11111110);
+    }
+
+    SECTION ("RESET 4") {
+        CPU c;
+        instruct.target = ArithmeticTarget::B;
+        instruct.bit_index = 0;
+
+        c.registers.b = 255;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.b == 0b11111110);
+    }
+
+    SECTION ("RESET 5") {
+        CPU c;
+        instruct.target = ArithmeticTarget::C;
+        instruct.bit_index = 0;
+
+        c.registers.c = 255;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.c == 0b11111110);
+    }
+
+    SECTION ("RESET 6") {
+        CPU c;
+        instruct.target = ArithmeticTarget::D;
+        instruct.bit_index = 0;
+
+        c.registers.d = 255;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.d == 0b11111110);
+    }
+
+    SECTION ("RESET 7") {
+        CPU c;
+        instruct.target = ArithmeticTarget::E;
+        instruct.bit_index = 0;
+
+        c.registers.e = 255;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.e == 0b11111110);
+    }
+
+    SECTION ("RESET 8") {
+        CPU c;
+        instruct.target = ArithmeticTarget::H;
+        instruct.bit_index = 0;
+
+        c.registers.h = 255;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.h == 0b11111110);
+    }
+
+    SECTION ("RESET 9") {
+        CPU c;
+        instruct.target = ArithmeticTarget::L;
+        instruct.bit_index = 0;
+
+        c.registers.l = 255;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.l == 0b11111110);
+    }
+}

--- a/tests/cpu_tests.cpp
+++ b/tests/cpu_tests.cpp
@@ -1007,3 +1007,159 @@ TEST_CASE("CPL Unit Tests", "[cpu][misc][cpl]") {
         REQUIRE(c.registers.f.half_carry == true);
     }
 }
+
+TEST_CASE("BIT Unit Tests", "[cpu][bit_opcode][bit]") {
+    Instruction instruct;
+    instruct.type = InstructionType::BIT;
+
+    SECTION ("BIT 1") {
+        CPU c;
+        instruct.target = ArithmeticTarget::A;
+        instruct.bit_index = 3;
+
+        c.registers.a = 0b00001000;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.f.zero == false);
+        REQUIRE(c.registers.f.subtract == false);
+        REQUIRE(c.registers.f.carry == false);
+        REQUIRE(c.registers.f.half_carry == true);
+    }
+
+    SECTION ("BIT 2") {
+        CPU c;
+        instruct.target = ArithmeticTarget::A;
+        instruct.bit_index = 2;
+
+        c.registers.a = 0b00001000;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.f.zero == true);
+        REQUIRE(c.registers.f.subtract == false);
+        REQUIRE(c.registers.f.carry == false);
+        REQUIRE(c.registers.f.half_carry == true);
+    }
+
+    SECTION ("BIT 3") {
+        CPU c;
+        instruct.target = ArithmeticTarget::A;
+        instruct.bit_index = 4;
+
+        c.registers.a = 0b00001000;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.f.zero == true);
+        REQUIRE(c.registers.f.subtract == false);
+        REQUIRE(c.registers.f.carry == false);
+        REQUIRE(c.registers.f.half_carry == true);
+    }
+
+    SECTION ("BIT 4") {
+        CPU c;
+        instruct.target = ArithmeticTarget::B;
+        instruct.bit_index = 3;
+
+        c.registers.b = 0b00001000;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.f.zero == false);
+        REQUIRE(c.registers.f.subtract == false);
+        REQUIRE(c.registers.f.carry == false);
+        REQUIRE(c.registers.f.half_carry == true);
+    }
+
+    SECTION ("BIT 5") {
+        CPU c;
+        instruct.target = ArithmeticTarget::C;
+        instruct.bit_index = 3;
+
+        c.registers.c = 0b00001000;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.f.zero == false);
+        REQUIRE(c.registers.f.subtract == false);
+        REQUIRE(c.registers.f.carry == false);
+        REQUIRE(c.registers.f.half_carry == true);
+    }
+
+    SECTION ("BIT 6") {
+        CPU c;
+        instruct.target = ArithmeticTarget::D;
+        instruct.bit_index = 3;
+
+        c.registers.d = 0b00001000;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.f.zero == false);
+        REQUIRE(c.registers.f.subtract == false);
+        REQUIRE(c.registers.f.carry == false);
+        REQUIRE(c.registers.f.half_carry == true);
+    }
+
+    SECTION ("BIT 7") {
+        CPU c;
+        instruct.target = ArithmeticTarget::E;
+        instruct.bit_index = 3;
+
+        c.registers.e = 0b00001000;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.f.zero == false);
+        REQUIRE(c.registers.f.subtract == false);
+        REQUIRE(c.registers.f.carry == false);
+        REQUIRE(c.registers.f.half_carry == true);
+    }
+
+    SECTION ("BIT 8") {
+        CPU c;
+        instruct.target = ArithmeticTarget::H;
+        instruct.bit_index = 3;
+
+        c.registers.h = 0b00001000;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.f.zero == false);
+        REQUIRE(c.registers.f.subtract == false);
+        REQUIRE(c.registers.f.carry == false);
+        REQUIRE(c.registers.f.half_carry == true);
+    }
+
+    SECTION ("BIT 9") {
+        CPU c;
+        instruct.target = ArithmeticTarget::L;
+        instruct.bit_index = 3;
+
+        c.registers.l = 0b00001000;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.f.zero == false);
+        REQUIRE(c.registers.f.subtract == false);
+        REQUIRE(c.registers.f.carry == false);
+        REQUIRE(c.registers.f.half_carry == true);
+    }
+
+    SECTION ("BIT 10 - Carry set to True") {
+        CPU c;
+        instruct.target = ArithmeticTarget::A;
+        instruct.bit_index = 3;
+
+        c.registers.a = 0b00001000;
+        c.registers.f.carry = true;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.f.zero == false);
+        REQUIRE(c.registers.f.subtract == false);
+        REQUIRE(c.registers.f.carry == true);
+        REQUIRE(c.registers.f.half_carry == true);
+    }
+}


### PR DESCRIPTION
# Issue
https://github.com/Sam-Coburn/gameboy_emulator/issues/6

# Changes
- Implemented the following CPU instructions and also created unit test cases for each:

1. BIT
2. SET
3. RESET

# Test Results
<img width="707" height="497" alt="Screenshot 2026-04-15 at 5 38 13 PM" src="https://github.com/user-attachments/assets/67415ef1-bf91-479c-9624-1e25d1b29a32" />
The code compiles successfully and all unit test cases pass successfully