### PR TITLE
Implementing 16-bit Arithmetic Operations in CPU Class

### DIFF
--- a/include/cpu.hpp
+++ b/include/cpu.hpp
@@ -4,7 +4,7 @@
 #include <iostream>
 #include <bitset>
 
-enum class ArithmeticTarget {
+enum class ArithmeticTarget8Bit {
     A, B, C, D, E, H, L
 };
 
@@ -17,7 +17,7 @@ enum class InstructionType {
 
 struct Instruction {
     InstructionType type;
-    ArithmeticTarget target;
+    ArithmeticTarget8Bit target;
     uint8_t bit_index;
 };
 
@@ -34,25 +34,25 @@ class CPU {
                     uint8_t value = 0;
 
                     switch (instruction.target) {
-                        case ArithmeticTarget::A:
+                        case ArithmeticTarget8Bit::A:
                             value = registers.a;
                             break;
-                        case ArithmeticTarget::B:
+                        case ArithmeticTarget8Bit::B:
                             value = registers.b;
                             break;
-                        case ArithmeticTarget::C:
+                        case ArithmeticTarget8Bit::C:
                             value = registers.c;
                             break;
-                        case ArithmeticTarget::D:
+                        case ArithmeticTarget8Bit::D:
                             value = registers.d;
                             break;
-                        case ArithmeticTarget::E:
+                        case ArithmeticTarget8Bit::E:
                             value = registers.e;
                             break;
-                        case ArithmeticTarget::H:
+                        case ArithmeticTarget8Bit::H:
                             value = registers.h;
                             break;
-                        case ArithmeticTarget::L:
+                        case ArithmeticTarget8Bit::L:
                             value = registers.l;
                             break;
                         default:
@@ -70,25 +70,25 @@ class CPU {
                     uint8_t value = 0;
 
                     switch (instruction.target) {
-                        case ArithmeticTarget::A:
+                        case ArithmeticTarget8Bit::A:
                             value = registers.a;
                             break;
-                        case ArithmeticTarget::B:
+                        case ArithmeticTarget8Bit::B:
                             value = registers.b;
                             break;
-                        case ArithmeticTarget::C:
+                        case ArithmeticTarget8Bit::C:
                             value = registers.c;
                             break;
-                        case ArithmeticTarget::D:
+                        case ArithmeticTarget8Bit::D:
                             value = registers.d;
                             break;
-                        case ArithmeticTarget::E:
+                        case ArithmeticTarget8Bit::E:
                             value = registers.e;
                             break;
-                        case ArithmeticTarget::H:
+                        case ArithmeticTarget8Bit::H:
                             value = registers.h;
                             break;
-                        case ArithmeticTarget::L:
+                        case ArithmeticTarget8Bit::L:
                             value = registers.l;
                             break;
                     }
@@ -104,25 +104,25 @@ class CPU {
                     uint8_t value = 0;
 
                     switch (instruction.target) {
-                        case ArithmeticTarget::A:
+                        case ArithmeticTarget8Bit::A:
                             value = registers.a;
                             break;
-                        case ArithmeticTarget::B:
+                        case ArithmeticTarget8Bit::B:
                             value = registers.b;
                             break;
-                        case ArithmeticTarget::C:
+                        case ArithmeticTarget8Bit::C:
                             value = registers.c;
                             break;
-                        case ArithmeticTarget::D:
+                        case ArithmeticTarget8Bit::D:
                             value = registers.d;
                             break;
-                        case ArithmeticTarget::E:
+                        case ArithmeticTarget8Bit::E:
                             value = registers.e;
                             break;
-                        case ArithmeticTarget::H:
+                        case ArithmeticTarget8Bit::H:
                             value = registers.h;
                             break;
-                        case ArithmeticTarget::L:
+                        case ArithmeticTarget8Bit::L:
                             value = registers.l;
                             break;
                     }
@@ -138,25 +138,25 @@ class CPU {
                     uint8_t value = 0;
 
                     switch (instruction.target) {
-                        case ArithmeticTarget::A:
+                        case ArithmeticTarget8Bit::A:
                             value = registers.a;
                             break;
-                        case ArithmeticTarget::B:
+                        case ArithmeticTarget8Bit::B:
                             value = registers.b;
                             break;
-                        case ArithmeticTarget::C:
+                        case ArithmeticTarget8Bit::C:
                             value = registers.c;
                             break;
-                        case ArithmeticTarget::D:
+                        case ArithmeticTarget8Bit::D:
                             value = registers.d;
                             break;
-                        case ArithmeticTarget::E:
+                        case ArithmeticTarget8Bit::E:
                             value = registers.e;
                             break;
-                        case ArithmeticTarget::H:
+                        case ArithmeticTarget8Bit::H:
                             value = registers.h;
                             break;
-                        case ArithmeticTarget::L:
+                        case ArithmeticTarget8Bit::L:
                             value = registers.l;
                             break;
                     }
@@ -172,25 +172,25 @@ class CPU {
                     uint8_t value = 0;
 
                     switch (instruction.target) {
-                        case ArithmeticTarget::A:
+                        case ArithmeticTarget8Bit::A:
                             value = registers.a;
                             break;
-                        case ArithmeticTarget::B:
+                        case ArithmeticTarget8Bit::B:
                             value = registers.b;
                             break;
-                        case ArithmeticTarget::C:
+                        case ArithmeticTarget8Bit::C:
                             value = registers.c;
                             break;
-                        case ArithmeticTarget::D:
+                        case ArithmeticTarget8Bit::D:
                             value = registers.d;
                             break;
-                        case ArithmeticTarget::E:
+                        case ArithmeticTarget8Bit::E:
                             value = registers.e;
                             break;
-                        case ArithmeticTarget::H:
+                        case ArithmeticTarget8Bit::H:
                             value = registers.h;
                             break;
-                        case ArithmeticTarget::L:
+                        case ArithmeticTarget8Bit::L:
                             value = registers.l;
                             break;
                     }
@@ -206,25 +206,25 @@ class CPU {
                     uint8_t value = 0;
 
                     switch (instruction.target) {
-                        case ArithmeticTarget::A:
+                        case ArithmeticTarget8Bit::A:
                             value = registers.a;
                             break;
-                        case ArithmeticTarget::B:
+                        case ArithmeticTarget8Bit::B:
                             value = registers.b;
                             break;
-                        case ArithmeticTarget::C:
+                        case ArithmeticTarget8Bit::C:
                             value = registers.c;
                             break;
-                        case ArithmeticTarget::D:
+                        case ArithmeticTarget8Bit::D:
                             value = registers.d;
                             break;
-                        case ArithmeticTarget::E:
+                        case ArithmeticTarget8Bit::E:
                             value = registers.e;
                             break;
-                        case ArithmeticTarget::H:
+                        case ArithmeticTarget8Bit::H:
                             value = registers.h;
                             break;
-                        case ArithmeticTarget::L:
+                        case ArithmeticTarget8Bit::L:
                             value = registers.l;
                             break;
                     }
@@ -240,25 +240,25 @@ class CPU {
                     uint8_t value = 0;
 
                     switch (instruction.target) {
-                        case ArithmeticTarget::A:
+                        case ArithmeticTarget8Bit::A:
                             value = registers.a;
                             break;
-                        case ArithmeticTarget::B:
+                        case ArithmeticTarget8Bit::B:
                             value = registers.b;
                             break;
-                        case ArithmeticTarget::C:
+                        case ArithmeticTarget8Bit::C:
                             value = registers.c;
                             break;
-                        case ArithmeticTarget::D:
+                        case ArithmeticTarget8Bit::D:
                             value = registers.d;
                             break;
-                        case ArithmeticTarget::E:
+                        case ArithmeticTarget8Bit::E:
                             value = registers.e;
                             break;
-                        case ArithmeticTarget::H:
+                        case ArithmeticTarget8Bit::H:
                             value = registers.h;
                             break;
-                        case ArithmeticTarget::L:
+                        case ArithmeticTarget8Bit::L:
                             value = registers.l;
                             break;
                     }
@@ -274,25 +274,25 @@ class CPU {
                     uint8_t value = 0;
 
                     switch (instruction.target) {
-                        case ArithmeticTarget::A:
+                        case ArithmeticTarget8Bit::A:
                             value = registers.a;
                             break;
-                        case ArithmeticTarget::B:
+                        case ArithmeticTarget8Bit::B:
                             value = registers.b;
                             break;
-                        case ArithmeticTarget::C:
+                        case ArithmeticTarget8Bit::C:
                             value = registers.c;
                             break;
-                        case ArithmeticTarget::D:
+                        case ArithmeticTarget8Bit::D:
                             value = registers.d;
                             break;
-                        case ArithmeticTarget::E:
+                        case ArithmeticTarget8Bit::E:
                             value = registers.e;
                             break;
-                        case ArithmeticTarget::H:
+                        case ArithmeticTarget8Bit::H:
                             value = registers.h;
                             break;
-                        case ArithmeticTarget::L:
+                        case ArithmeticTarget8Bit::L:
                             value = registers.l;
                             break;
                     }
@@ -305,25 +305,25 @@ class CPU {
                 // INC Instruction increments value of target register
                 case InstructionType::INC: {
                     switch (instruction.target) {
-                        case ArithmeticTarget::A:
+                        case ArithmeticTarget8Bit::A:
                             registers.a = inc(registers.a);
                             break;
-                        case ArithmeticTarget::B:
+                        case ArithmeticTarget8Bit::B:
                             registers.b = inc(registers.b);
                             break;
-                        case ArithmeticTarget::C:
+                        case ArithmeticTarget8Bit::C:
                             registers.c = inc(registers.c);
                             break;
-                        case ArithmeticTarget::D:
+                        case ArithmeticTarget8Bit::D:
                             registers.d = inc(registers.d);
                             break;
-                        case ArithmeticTarget::E:
+                        case ArithmeticTarget8Bit::E:
                             registers.e = inc(registers.e);
                             break;
-                        case ArithmeticTarget::H:
+                        case ArithmeticTarget8Bit::H:
                             registers.h = inc(registers.h);
                             break;
-                        case ArithmeticTarget::L:
+                        case ArithmeticTarget8Bit::L:
                             registers.l = inc(registers.l);
                             break;
                     }
@@ -334,25 +334,25 @@ class CPU {
                 // DEC Instruction increments value of target register
                 case InstructionType::DEC: {
                     switch (instruction.target) {
-                        case ArithmeticTarget::A:
+                        case ArithmeticTarget8Bit::A:
                             registers.a = dec(registers.a);
                             break;
-                        case ArithmeticTarget::B:
+                        case ArithmeticTarget8Bit::B:
                             registers.b = dec(registers.b);
                             break;
-                        case ArithmeticTarget::C:
+                        case ArithmeticTarget8Bit::C:
                             registers.c = dec(registers.c);
                             break;
-                        case ArithmeticTarget::D:
+                        case ArithmeticTarget8Bit::D:
                             registers.d = dec(registers.d);
                             break;
-                        case ArithmeticTarget::E:
+                        case ArithmeticTarget8Bit::E:
                             registers.e = dec(registers.e);
                             break;
-                        case ArithmeticTarget::H:
+                        case ArithmeticTarget8Bit::H:
                             registers.h = dec(registers.h);
                             break;
-                        case ArithmeticTarget::L:
+                        case ArithmeticTarget8Bit::L:
                             registers.l = dec(registers.l);
                             break;
                     }
@@ -363,25 +363,25 @@ class CPU {
                 // SWAP Instruction swaps the values of the upper and lower nibbles of the target register
                 case InstructionType::SWAP: {
                     switch (instruction.target) {
-                        case ArithmeticTarget::A:
+                        case ArithmeticTarget8Bit::A:
                             registers.a = swap(registers.a);
                             break;
-                        case ArithmeticTarget::B:
+                        case ArithmeticTarget8Bit::B:
                             registers.b = swap(registers.b);
                             break;
-                        case ArithmeticTarget::C:
+                        case ArithmeticTarget8Bit::C:
                             registers.c = swap(registers.c);
                             break;
-                        case ArithmeticTarget::D:
+                        case ArithmeticTarget8Bit::D:
                             registers.d = swap(registers.d);
                             break;
-                        case ArithmeticTarget::E:
+                        case ArithmeticTarget8Bit::E:
                             registers.e = swap(registers.e);
                             break;
-                        case ArithmeticTarget::H:
+                        case ArithmeticTarget8Bit::H:
                             registers.h = swap(registers.h);
                             break;
-                        case ArithmeticTarget::L:
+                        case ArithmeticTarget8Bit::L:
                             registers.l = swap(registers.l);
                             break;
                     }
@@ -434,25 +434,25 @@ class CPU {
                     uint8_t value = 0;
 
                     switch (instruction.target) {
-                        case ArithmeticTarget::A:
+                        case ArithmeticTarget8Bit::A:
                             value = registers.a;
                             break;
-                        case ArithmeticTarget::B:
+                        case ArithmeticTarget8Bit::B:
                             value = registers.b;
                             break;
-                        case ArithmeticTarget::C:
+                        case ArithmeticTarget8Bit::C:
                             value = registers.c;
                             break;
-                        case ArithmeticTarget::D:
+                        case ArithmeticTarget8Bit::D:
                             value = registers.d;
                             break;
-                        case ArithmeticTarget::E:
+                        case ArithmeticTarget8Bit::E:
                             value = registers.e;
                             break;
-                        case ArithmeticTarget::H:
+                        case ArithmeticTarget8Bit::H:
                             value = registers.h;
                             break;
-                        case ArithmeticTarget::L:
+                        case ArithmeticTarget8Bit::L:
                             value = registers.l;
                             break;
                     }
@@ -472,25 +472,25 @@ class CPU {
                     uint8_t bit_index = instruction.bit_index;
 
                     switch (instruction.target) {
-                        case ArithmeticTarget::A:
+                        case ArithmeticTarget8Bit::A:
                             registers.a = registers.a | (1 << bit_index);
                             break;
-                        case ArithmeticTarget::B:
+                        case ArithmeticTarget8Bit::B:
                             registers.b = registers.b | (1 << bit_index);
                             break;
-                        case ArithmeticTarget::C:
+                        case ArithmeticTarget8Bit::C:
                             registers.c = registers.c | (1 << bit_index);
                             break;
-                        case ArithmeticTarget::D:
+                        case ArithmeticTarget8Bit::D:
                             registers.d = registers.d | (1 << bit_index);
                             break;
-                        case ArithmeticTarget::E:
+                        case ArithmeticTarget8Bit::E:
                             registers.e = registers.e | (1 << bit_index);
                             break;
-                        case ArithmeticTarget::H:
+                        case ArithmeticTarget8Bit::H:
                             registers.h = registers.h | (1 << bit_index);
                             break;
-                        case ArithmeticTarget::L:
+                        case ArithmeticTarget8Bit::L:
                             registers.l = registers.l | (1 << bit_index);
                             break;
                     }
@@ -503,25 +503,25 @@ class CPU {
                     uint8_t bit_index = instruction.bit_index;
 
                     switch (instruction.target) {
-                        case ArithmeticTarget::A:
+                        case ArithmeticTarget8Bit::A:
                             registers.a = registers.a & ~(1 << bit_index);
                             break;
-                        case ArithmeticTarget::B:
+                        case ArithmeticTarget8Bit::B:
                             registers.b = registers.b & ~(1 << bit_index);
                             break;
-                        case ArithmeticTarget::C:
+                        case ArithmeticTarget8Bit::C:
                             registers.c = registers.c & ~(1 << bit_index);
                             break;
-                        case ArithmeticTarget::D:
+                        case ArithmeticTarget8Bit::D:
                             registers.d = registers.d & ~(1 << bit_index);
                             break;
-                        case ArithmeticTarget::E:
+                        case ArithmeticTarget8Bit::E:
                             registers.e = registers.e & ~(1 << bit_index);
                             break;
-                        case ArithmeticTarget::H:
+                        case ArithmeticTarget8Bit::H:
                             registers.h = registers.h & ~(1 << bit_index);
                             break;
-                        case ArithmeticTarget::L:
+                        case ArithmeticTarget8Bit::L:
                             registers.l = registers.l & ~(1 << bit_index);
                             break;
                     }

--- a/include/cpu.hpp
+++ b/include/cpu.hpp
@@ -8,22 +8,29 @@ enum class ArithmeticTarget8Bit {
     A, B, C, D, E, H, L
 };
 
+enum class ArithmeticTarget16Bit {
+    BC, DE, HL, SP
+};
+
 enum class InstructionType {
     ADD, ADC, SUB, SBC, AND,
     OR, XOR, CP, INC, DEC,
     SWAP, SCF, CCF, CPL, BIT,
-    SET, RESET
+    SET, RESET, ADDHL
 };
 
 struct Instruction {
     InstructionType type;
-    ArithmeticTarget8Bit target;
+    ArithmeticTarget8Bit target_8bit;
+    ArithmeticTarget16Bit target_16bit;
     uint8_t bit_index;
 };
 
 class CPU {
     public:
         Registers registers;
+        uint16_t sp = 0xFFFE;
+
         void execute(const Instruction& instruction) {
             switch (instruction.type) {
 
@@ -33,7 +40,7 @@ class CPU {
                 case InstructionType::ADD: {
                     uint8_t value = 0;
 
-                    switch (instruction.target) {
+                    switch (instruction.target_8bit) {
                         case ArithmeticTarget8Bit::A:
                             value = registers.a;
                             break;
@@ -69,7 +76,7 @@ class CPU {
                 case InstructionType::ADC: {
                     uint8_t value = 0;
 
-                    switch (instruction.target) {
+                    switch (instruction.target_8bit) {
                         case ArithmeticTarget8Bit::A:
                             value = registers.a;
                             break;
@@ -103,7 +110,7 @@ class CPU {
                 case InstructionType::SUB: {
                     uint8_t value = 0;
 
-                    switch (instruction.target) {
+                    switch (instruction.target_8bit) {
                         case ArithmeticTarget8Bit::A:
                             value = registers.a;
                             break;
@@ -137,7 +144,7 @@ class CPU {
                 case InstructionType::SBC: {
                     uint8_t value = 0;
 
-                    switch (instruction.target) {
+                    switch (instruction.target_8bit) {
                         case ArithmeticTarget8Bit::A:
                             value = registers.a;
                             break;
@@ -171,7 +178,7 @@ class CPU {
                 case InstructionType::AND: {
                     uint8_t value = 0;
 
-                    switch (instruction.target) {
+                    switch (instruction.target_8bit) {
                         case ArithmeticTarget8Bit::A:
                             value = registers.a;
                             break;
@@ -205,7 +212,7 @@ class CPU {
                 case InstructionType::OR: {
                     uint8_t value = 0;
 
-                    switch (instruction.target) {
+                    switch (instruction.target_8bit) {
                         case ArithmeticTarget8Bit::A:
                             value = registers.a;
                             break;
@@ -239,7 +246,7 @@ class CPU {
                 case InstructionType::XOR: {
                     uint8_t value = 0;
 
-                    switch (instruction.target) {
+                    switch (instruction.target_8bit) {
                         case ArithmeticTarget8Bit::A:
                             value = registers.a;
                             break;
@@ -273,7 +280,7 @@ class CPU {
                 case InstructionType::CP: {
                     uint8_t value = 0;
 
-                    switch (instruction.target) {
+                    switch (instruction.target_8bit) {
                         case ArithmeticTarget8Bit::A:
                             value = registers.a;
                             break;
@@ -304,7 +311,7 @@ class CPU {
 
                 // INC Instruction increments value of target register
                 case InstructionType::INC: {
-                    switch (instruction.target) {
+                    switch (instruction.target_8bit) {
                         case ArithmeticTarget8Bit::A:
                             registers.a = inc(registers.a);
                             break;
@@ -333,7 +340,7 @@ class CPU {
 
                 // DEC Instruction increments value of target register
                 case InstructionType::DEC: {
-                    switch (instruction.target) {
+                    switch (instruction.target_8bit) {
                         case ArithmeticTarget8Bit::A:
                             registers.a = dec(registers.a);
                             break;
@@ -362,7 +369,7 @@ class CPU {
 
                 // SWAP Instruction swaps the values of the upper and lower nibbles of the target register
                 case InstructionType::SWAP: {
-                    switch (instruction.target) {
+                    switch (instruction.target_8bit) {
                         case ArithmeticTarget8Bit::A:
                             registers.a = swap(registers.a);
                             break;
@@ -433,7 +440,7 @@ class CPU {
                     uint8_t bit_index = instruction.bit_index;
                     uint8_t value = 0;
 
-                    switch (instruction.target) {
+                    switch (instruction.target_8bit) {
                         case ArithmeticTarget8Bit::A:
                             value = registers.a;
                             break;
@@ -471,7 +478,7 @@ class CPU {
                 case InstructionType::SET: {
                     uint8_t bit_index = instruction.bit_index;
 
-                    switch (instruction.target) {
+                    switch (instruction.target_8bit) {
                         case ArithmeticTarget8Bit::A:
                             registers.a = registers.a | (1 << bit_index);
                             break;
@@ -502,7 +509,7 @@ class CPU {
                 case InstructionType::RESET: {
                     uint8_t bit_index = instruction.bit_index;
 
-                    switch (instruction.target) {
+                    switch (instruction.target_8bit) {
                         case ArithmeticTarget8Bit::A:
                             registers.a = registers.a & ~(1 << bit_index);
                             break;
@@ -525,6 +532,31 @@ class CPU {
                             registers.l = registers.l & ~(1 << bit_index);
                             break;
                     }
+
+                    break;
+                }
+
+                // ADDHL Instruction adds the contents of the given 16-bit register to the HL register
+                case InstructionType::ADDHL: {
+                    uint16_t value = 0;
+
+                    switch (instruction.target_16bit) {
+                        case ArithmeticTarget16Bit::BC:
+                            value = registers.get_bc();
+                            break;
+                        case ArithmeticTarget16Bit::DE:
+                            value = registers.get_de();
+                            break;
+                        case ArithmeticTarget16Bit::HL:
+                            value = registers.get_hl();
+                            break;
+                        case ArithmeticTarget16Bit::SP:
+                            value = sp;
+                            break;
+                    }
+
+                    uint16_t new_value = add_hl(value);
+                    registers.set_hl(new_value);
 
                     break;
                 }
@@ -651,6 +683,18 @@ class CPU {
             registers.f.subtract = false;
             registers.f.carry = false;
             registers.f.half_carry = false;
+
+            return result;
+        }
+
+        uint16_t add_hl(uint16_t value) {
+            uint16_t result = registers.get_hl() + value;
+            bool overflowed = result < registers.get_hl();
+
+            registers.f.zero = registers.f.zero; // ADDHL doesnt affect the zero flag, it's left alone
+            registers.f.subtract = false;
+            registers.f.carry = overflowed;
+            registers.f.half_carry = (registers.get_hl() & 0xFFF) + (value & 0xFFF) > 0xFFF;
 
             return result;
         }

--- a/tests/cpu_tests.cpp
+++ b/tests/cpu_tests.cpp
@@ -21,7 +21,7 @@ TEST_CASE("Default constructor initializes CPU successfully", "[cpu]") {
 TEST_CASE("ADD Unit Tests", "[cpu][8-bit][add]") {
     Instruction instruct;
     instruct.type = InstructionType::ADD;
-    instruct.target = ArithmeticTarget8Bit::B;
+    instruct.target_8bit = ArithmeticTarget8Bit::B;
 
     SECTION ("ADD w/o Overflow") {
         CPU c1;
@@ -87,7 +87,7 @@ TEST_CASE("ADD Unit Tests", "[cpu][8-bit][add]") {
 TEST_CASE("ADC Unit Tests", "[cpu][8-bit][adc]") {
     Instruction instruct;
     instruct.type = InstructionType::ADC;
-    instruct.target = ArithmeticTarget8Bit::B;
+    instruct.target_8bit = ArithmeticTarget8Bit::B;
 
     SECTION ("ADC w/o Overflow - No Carry") {
         CPU c1;
@@ -157,7 +157,7 @@ TEST_CASE("ADC Unit Tests", "[cpu][8-bit][adc]") {
 TEST_CASE("SUB Unit Tests", "[cpu][8-bit][sub]") {
     Instruction instruct;
     instruct.type = InstructionType::SUB;
-    instruct.target = ArithmeticTarget8Bit::B;
+    instruct.target_8bit = ArithmeticTarget8Bit::B;
 
     SECTION ("SUB w/o Overflow") {
         CPU c1;
@@ -207,7 +207,7 @@ TEST_CASE("SUB Unit Tests", "[cpu][8-bit][sub]") {
 TEST_CASE("SBC Unit Tests", "[cpu][8-bit][sbc]") {
     Instruction instruct;
     instruct.type = InstructionType::SBC;
-    instruct.target = ArithmeticTarget8Bit::B;
+    instruct.target_8bit = ArithmeticTarget8Bit::B;
 
     SECTION ("SBC w/o Overflow - No Carry") {
         CPU c1;
@@ -245,7 +245,7 @@ TEST_CASE("SBC Unit Tests", "[cpu][8-bit][sbc]") {
 TEST_CASE("AND Unit Tests", "[cpu][8-bit][and]") {
     Instruction instruct;
     instruct.type = InstructionType::AND;
-    instruct.target = ArithmeticTarget8Bit::B;
+    instruct.target_8bit = ArithmeticTarget8Bit::B;
 
     SECTION ("AND - No Zero") {
         CPU c1;
@@ -281,7 +281,7 @@ TEST_CASE("AND Unit Tests", "[cpu][8-bit][and]") {
 TEST_CASE("OR Unit Tests", "[cpu][8-bit][or]") {
     Instruction instruct;
     instruct.type = InstructionType::OR;
-    instruct.target = ArithmeticTarget8Bit::B;
+    instruct.target_8bit = ArithmeticTarget8Bit::B;
 
     SECTION ("OR - No Zero") {
         CPU c1;
@@ -317,7 +317,7 @@ TEST_CASE("OR Unit Tests", "[cpu][8-bit][or]") {
 TEST_CASE("XOR Unit Tests", "[cpu][8-bit][xor]") {
     Instruction instruct;
     instruct.type = InstructionType::XOR;
-    instruct.target = ArithmeticTarget8Bit::B;
+    instruct.target_8bit = ArithmeticTarget8Bit::B;
 
     SECTION ("XOR 1") {
         CPU c1;
@@ -353,7 +353,7 @@ TEST_CASE("XOR Unit Tests", "[cpu][8-bit][xor]") {
 TEST_CASE("CP Unit Tests", "[cpu][8-bit][cp]") {
     Instruction instruct;
     instruct.type = InstructionType::CP;
-    instruct.target = ArithmeticTarget8Bit::B;
+    instruct.target_8bit = ArithmeticTarget8Bit::B;
 
     SECTION ("CP w/o Overflow") {
         CPU c1;
@@ -405,7 +405,7 @@ TEST_CASE("INC Unit Tests", "[cpu][8-bit][inc]") {
     instruct.type = InstructionType::INC;
 
     SECTION ("INC Register A") {
-        instruct.target = ArithmeticTarget8Bit::A;
+        instruct.target_8bit = ArithmeticTarget8Bit::A;
 
         CPU c;
 
@@ -421,7 +421,7 @@ TEST_CASE("INC Unit Tests", "[cpu][8-bit][inc]") {
     }
 
     SECTION ("INC Register B") {
-        instruct.target = ArithmeticTarget8Bit::B;
+        instruct.target_8bit = ArithmeticTarget8Bit::B;
 
         CPU c;
 
@@ -437,7 +437,7 @@ TEST_CASE("INC Unit Tests", "[cpu][8-bit][inc]") {
     }
 
     SECTION ("INC Register C") {
-        instruct.target = ArithmeticTarget8Bit::C;
+        instruct.target_8bit = ArithmeticTarget8Bit::C;
 
         CPU c;
 
@@ -453,7 +453,7 @@ TEST_CASE("INC Unit Tests", "[cpu][8-bit][inc]") {
     }
 
     SECTION ("INC Register D") {
-        instruct.target = ArithmeticTarget8Bit::D;
+        instruct.target_8bit = ArithmeticTarget8Bit::D;
 
         CPU c;
 
@@ -469,7 +469,7 @@ TEST_CASE("INC Unit Tests", "[cpu][8-bit][inc]") {
     }
 
     SECTION ("INC Register E") {
-        instruct.target = ArithmeticTarget8Bit::E;
+        instruct.target_8bit = ArithmeticTarget8Bit::E;
 
         CPU c;
 
@@ -485,7 +485,7 @@ TEST_CASE("INC Unit Tests", "[cpu][8-bit][inc]") {
     }
 
     SECTION ("INC Register H") {
-        instruct.target = ArithmeticTarget8Bit::H;
+        instruct.target_8bit = ArithmeticTarget8Bit::H;
 
         CPU c;
 
@@ -501,7 +501,7 @@ TEST_CASE("INC Unit Tests", "[cpu][8-bit][inc]") {
     }
 
     SECTION ("INC Register L") {
-        instruct.target = ArithmeticTarget8Bit::L;
+        instruct.target_8bit = ArithmeticTarget8Bit::L;
 
         CPU c;
 
@@ -517,7 +517,7 @@ TEST_CASE("INC Unit Tests", "[cpu][8-bit][inc]") {
     }
 
     SECTION ("INC - Overflow - Carry Set to False") {
-        instruct.target = ArithmeticTarget8Bit::B;
+        instruct.target_8bit = ArithmeticTarget8Bit::B;
 
         CPU c;
 
@@ -534,7 +534,7 @@ TEST_CASE("INC Unit Tests", "[cpu][8-bit][inc]") {
     }
 
     SECTION ("INC - Overflow - Carry Set to True") {
-        instruct.target = ArithmeticTarget8Bit::B;
+        instruct.target_8bit = ArithmeticTarget8Bit::B;
 
         CPU c;
 
@@ -551,7 +551,7 @@ TEST_CASE("INC Unit Tests", "[cpu][8-bit][inc]") {
     }
 
     SECTION ("INC - Half Carry") {
-        instruct.target = ArithmeticTarget8Bit::B;
+        instruct.target_8bit = ArithmeticTarget8Bit::B;
 
         CPU c;
 
@@ -572,7 +572,7 @@ TEST_CASE("DEC Unit Tests", "[cpu][8-bit][dec]") {
     instruct.type = InstructionType::DEC;
 
     SECTION ("DEC Register A") {
-        instruct.target = ArithmeticTarget8Bit::A;
+        instruct.target_8bit = ArithmeticTarget8Bit::A;
 
         CPU c;
 
@@ -588,7 +588,7 @@ TEST_CASE("DEC Unit Tests", "[cpu][8-bit][dec]") {
     }
 
     SECTION ("DEC Register B") {
-        instruct.target = ArithmeticTarget8Bit::B;
+        instruct.target_8bit = ArithmeticTarget8Bit::B;
 
         CPU c;
 
@@ -604,7 +604,7 @@ TEST_CASE("DEC Unit Tests", "[cpu][8-bit][dec]") {
     }
 
     SECTION ("DEC Register C") {
-        instruct.target = ArithmeticTarget8Bit::C;
+        instruct.target_8bit = ArithmeticTarget8Bit::C;
 
         CPU c;
 
@@ -620,7 +620,7 @@ TEST_CASE("DEC Unit Tests", "[cpu][8-bit][dec]") {
     }
 
     SECTION ("DEC Register D") {
-        instruct.target = ArithmeticTarget8Bit::D;
+        instruct.target_8bit = ArithmeticTarget8Bit::D;
 
         CPU c;
 
@@ -636,7 +636,7 @@ TEST_CASE("DEC Unit Tests", "[cpu][8-bit][dec]") {
     }
 
     SECTION ("DEC Register E") {
-        instruct.target = ArithmeticTarget8Bit::E;
+        instruct.target_8bit = ArithmeticTarget8Bit::E;
 
         CPU c;
 
@@ -652,7 +652,7 @@ TEST_CASE("DEC Unit Tests", "[cpu][8-bit][dec]") {
     }
 
     SECTION ("DEC Register H") {
-        instruct.target = ArithmeticTarget8Bit::H;
+        instruct.target_8bit = ArithmeticTarget8Bit::H;
 
         CPU c;
 
@@ -668,7 +668,7 @@ TEST_CASE("DEC Unit Tests", "[cpu][8-bit][dec]") {
     }
 
     SECTION ("DEC Register L") {
-        instruct.target = ArithmeticTarget8Bit::L;
+        instruct.target_8bit = ArithmeticTarget8Bit::L;
 
         CPU c;
 
@@ -684,7 +684,7 @@ TEST_CASE("DEC Unit Tests", "[cpu][8-bit][dec]") {
     }
 
     SECTION ("DEC - Decrementing 0") {
-        instruct.target = ArithmeticTarget8Bit::B;
+        instruct.target_8bit = ArithmeticTarget8Bit::B;
 
         CPU c;
 
@@ -700,7 +700,7 @@ TEST_CASE("DEC Unit Tests", "[cpu][8-bit][dec]") {
     }
 
     SECTION ("DEC - Decrementing 1") {
-        instruct.target = ArithmeticTarget8Bit::B;
+        instruct.target_8bit = ArithmeticTarget8Bit::B;
 
         CPU c;
 
@@ -721,7 +721,7 @@ TEST_CASE("SWAP Unit Tests", "[cpu][misc][swap]") {
     instruct.type = InstructionType::SWAP;
 
     SECTION ("SWAP Register A") {
-        instruct.target = ArithmeticTarget8Bit::A;
+        instruct.target_8bit = ArithmeticTarget8Bit::A;
 
         CPU c;
 
@@ -737,7 +737,7 @@ TEST_CASE("SWAP Unit Tests", "[cpu][misc][swap]") {
     }
 
     SECTION ("SWAP Register B") {
-        instruct.target = ArithmeticTarget8Bit::B;
+        instruct.target_8bit = ArithmeticTarget8Bit::B;
 
         CPU c;
 
@@ -753,7 +753,7 @@ TEST_CASE("SWAP Unit Tests", "[cpu][misc][swap]") {
     }
 
     SECTION ("SWAP Register C") {
-        instruct.target = ArithmeticTarget8Bit::C;
+        instruct.target_8bit = ArithmeticTarget8Bit::C;
 
         CPU c;
 
@@ -769,7 +769,7 @@ TEST_CASE("SWAP Unit Tests", "[cpu][misc][swap]") {
     }
 
     SECTION ("SWAP Register D") {
-        instruct.target = ArithmeticTarget8Bit::D;
+        instruct.target_8bit = ArithmeticTarget8Bit::D;
 
         CPU c;
 
@@ -785,7 +785,7 @@ TEST_CASE("SWAP Unit Tests", "[cpu][misc][swap]") {
     }
 
     SECTION ("SWAP Register E") {
-        instruct.target = ArithmeticTarget8Bit::E;
+        instruct.target_8bit = ArithmeticTarget8Bit::E;
 
         CPU c;
 
@@ -801,7 +801,7 @@ TEST_CASE("SWAP Unit Tests", "[cpu][misc][swap]") {
     }
 
     SECTION ("SWAP Register H") {
-        instruct.target = ArithmeticTarget8Bit::H;
+        instruct.target_8bit = ArithmeticTarget8Bit::H;
 
         CPU c;
 
@@ -817,7 +817,7 @@ TEST_CASE("SWAP Unit Tests", "[cpu][misc][swap]") {
     }
 
     SECTION ("SWAP Register L") {
-        instruct.target = ArithmeticTarget8Bit::L;
+        instruct.target_8bit = ArithmeticTarget8Bit::L;
 
         CPU c;
 
@@ -1014,7 +1014,7 @@ TEST_CASE("BIT Unit Tests", "[cpu][bit_opcode][bit]") {
 
     SECTION ("BIT 1") {
         CPU c;
-        instruct.target = ArithmeticTarget8Bit::A;
+        instruct.target_8bit = ArithmeticTarget8Bit::A;
         instruct.bit_index = 3;
 
         c.registers.a = 0b00001000;
@@ -1029,7 +1029,7 @@ TEST_CASE("BIT Unit Tests", "[cpu][bit_opcode][bit]") {
 
     SECTION ("BIT 2") {
         CPU c;
-        instruct.target = ArithmeticTarget8Bit::A;
+        instruct.target_8bit = ArithmeticTarget8Bit::A;
         instruct.bit_index = 2;
 
         c.registers.a = 0b00001000;
@@ -1044,7 +1044,7 @@ TEST_CASE("BIT Unit Tests", "[cpu][bit_opcode][bit]") {
 
     SECTION ("BIT 3") {
         CPU c;
-        instruct.target = ArithmeticTarget8Bit::A;
+        instruct.target_8bit = ArithmeticTarget8Bit::A;
         instruct.bit_index = 4;
 
         c.registers.a = 0b00001000;
@@ -1059,7 +1059,7 @@ TEST_CASE("BIT Unit Tests", "[cpu][bit_opcode][bit]") {
 
     SECTION ("BIT 4") {
         CPU c;
-        instruct.target = ArithmeticTarget8Bit::B;
+        instruct.target_8bit = ArithmeticTarget8Bit::B;
         instruct.bit_index = 3;
 
         c.registers.b = 0b00001000;
@@ -1074,7 +1074,7 @@ TEST_CASE("BIT Unit Tests", "[cpu][bit_opcode][bit]") {
 
     SECTION ("BIT 5") {
         CPU c;
-        instruct.target = ArithmeticTarget8Bit::C;
+        instruct.target_8bit = ArithmeticTarget8Bit::C;
         instruct.bit_index = 3;
 
         c.registers.c = 0b00001000;
@@ -1089,7 +1089,7 @@ TEST_CASE("BIT Unit Tests", "[cpu][bit_opcode][bit]") {
 
     SECTION ("BIT 6") {
         CPU c;
-        instruct.target = ArithmeticTarget8Bit::D;
+        instruct.target_8bit = ArithmeticTarget8Bit::D;
         instruct.bit_index = 3;
 
         c.registers.d = 0b00001000;
@@ -1104,7 +1104,7 @@ TEST_CASE("BIT Unit Tests", "[cpu][bit_opcode][bit]") {
 
     SECTION ("BIT 7") {
         CPU c;
-        instruct.target = ArithmeticTarget8Bit::E;
+        instruct.target_8bit = ArithmeticTarget8Bit::E;
         instruct.bit_index = 3;
 
         c.registers.e = 0b00001000;
@@ -1119,7 +1119,7 @@ TEST_CASE("BIT Unit Tests", "[cpu][bit_opcode][bit]") {
 
     SECTION ("BIT 8") {
         CPU c;
-        instruct.target = ArithmeticTarget8Bit::H;
+        instruct.target_8bit = ArithmeticTarget8Bit::H;
         instruct.bit_index = 3;
 
         c.registers.h = 0b00001000;
@@ -1134,7 +1134,7 @@ TEST_CASE("BIT Unit Tests", "[cpu][bit_opcode][bit]") {
 
     SECTION ("BIT 9") {
         CPU c;
-        instruct.target = ArithmeticTarget8Bit::L;
+        instruct.target_8bit = ArithmeticTarget8Bit::L;
         instruct.bit_index = 3;
 
         c.registers.l = 0b00001000;
@@ -1149,7 +1149,7 @@ TEST_CASE("BIT Unit Tests", "[cpu][bit_opcode][bit]") {
 
     SECTION ("BIT 10 - Carry set to True") {
         CPU c;
-        instruct.target = ArithmeticTarget8Bit::A;
+        instruct.target_8bit = ArithmeticTarget8Bit::A;
         instruct.bit_index = 3;
 
         c.registers.a = 0b00001000;
@@ -1170,7 +1170,7 @@ TEST_CASE("SET Unit Tests", "[cpu][bit_opcode][set]") {
 
     SECTION ("SET 1") {
         CPU c;
-        instruct.target = ArithmeticTarget8Bit::A;
+        instruct.target_8bit = ArithmeticTarget8Bit::A;
         instruct.bit_index = 3;
 
         c.registers.a = 0;
@@ -1182,7 +1182,7 @@ TEST_CASE("SET Unit Tests", "[cpu][bit_opcode][set]") {
 
     SECTION ("SET 2") {
         CPU c;
-        instruct.target = ArithmeticTarget8Bit::A;
+        instruct.target_8bit = ArithmeticTarget8Bit::A;
         instruct.bit_index = 7;
 
         c.registers.a = 0;
@@ -1194,7 +1194,7 @@ TEST_CASE("SET Unit Tests", "[cpu][bit_opcode][set]") {
 
     SECTION ("SET 3") {
         CPU c;
-        instruct.target = ArithmeticTarget8Bit::A;
+        instruct.target_8bit = ArithmeticTarget8Bit::A;
         instruct.bit_index = 0;
 
         c.registers.a = 0;
@@ -1206,7 +1206,7 @@ TEST_CASE("SET Unit Tests", "[cpu][bit_opcode][set]") {
 
     SECTION ("SET 4") {
         CPU c;
-        instruct.target = ArithmeticTarget8Bit::B;
+        instruct.target_8bit = ArithmeticTarget8Bit::B;
         instruct.bit_index = 3;
 
         c.registers.b = 0;
@@ -1218,7 +1218,7 @@ TEST_CASE("SET Unit Tests", "[cpu][bit_opcode][set]") {
 
     SECTION ("SET 5") {
         CPU c;
-        instruct.target = ArithmeticTarget8Bit::C;
+        instruct.target_8bit = ArithmeticTarget8Bit::C;
         instruct.bit_index = 3;
 
         c.registers.c = 0;
@@ -1230,7 +1230,7 @@ TEST_CASE("SET Unit Tests", "[cpu][bit_opcode][set]") {
 
     SECTION ("SET 6") {
         CPU c;
-        instruct.target = ArithmeticTarget8Bit::D;
+        instruct.target_8bit = ArithmeticTarget8Bit::D;
         instruct.bit_index = 3;
 
         c.registers.d = 0;
@@ -1242,7 +1242,7 @@ TEST_CASE("SET Unit Tests", "[cpu][bit_opcode][set]") {
 
     SECTION ("SET 7") {
         CPU c;
-        instruct.target = ArithmeticTarget8Bit::E;
+        instruct.target_8bit = ArithmeticTarget8Bit::E;
         instruct.bit_index = 3;
 
         c.registers.e = 0;
@@ -1254,7 +1254,7 @@ TEST_CASE("SET Unit Tests", "[cpu][bit_opcode][set]") {
 
     SECTION ("SET 8") {
         CPU c;
-        instruct.target = ArithmeticTarget8Bit::H;
+        instruct.target_8bit = ArithmeticTarget8Bit::H;
         instruct.bit_index = 3;
 
         c.registers.h = 0;
@@ -1266,7 +1266,7 @@ TEST_CASE("SET Unit Tests", "[cpu][bit_opcode][set]") {
 
     SECTION ("SET 9") {
         CPU c;
-        instruct.target = ArithmeticTarget8Bit::L;
+        instruct.target_8bit = ArithmeticTarget8Bit::L;
         instruct.bit_index = 3;
 
         c.registers.l = 0;
@@ -1283,7 +1283,7 @@ TEST_CASE("RESET Unit Tests", "[cpu][bit_opcode][reset]") {
 
     SECTION ("RESET 1") {
         CPU c;
-        instruct.target = ArithmeticTarget8Bit::A;
+        instruct.target_8bit = ArithmeticTarget8Bit::A;
         instruct.bit_index = 3;
 
         c.registers.a = 255;
@@ -1295,7 +1295,7 @@ TEST_CASE("RESET Unit Tests", "[cpu][bit_opcode][reset]") {
 
     SECTION ("RESET 2") {
         CPU c;
-        instruct.target = ArithmeticTarget8Bit::A;
+        instruct.target_8bit = ArithmeticTarget8Bit::A;
         instruct.bit_index = 7;
 
         c.registers.a = 255;
@@ -1307,7 +1307,7 @@ TEST_CASE("RESET Unit Tests", "[cpu][bit_opcode][reset]") {
 
     SECTION ("RESET 3") {
         CPU c;
-        instruct.target = ArithmeticTarget8Bit::A;
+        instruct.target_8bit = ArithmeticTarget8Bit::A;
         instruct.bit_index = 0;
 
         c.registers.a = 255;
@@ -1319,7 +1319,7 @@ TEST_CASE("RESET Unit Tests", "[cpu][bit_opcode][reset]") {
 
     SECTION ("RESET 4") {
         CPU c;
-        instruct.target = ArithmeticTarget8Bit::B;
+        instruct.target_8bit = ArithmeticTarget8Bit::B;
         instruct.bit_index = 0;
 
         c.registers.b = 255;
@@ -1331,7 +1331,7 @@ TEST_CASE("RESET Unit Tests", "[cpu][bit_opcode][reset]") {
 
     SECTION ("RESET 5") {
         CPU c;
-        instruct.target = ArithmeticTarget8Bit::C;
+        instruct.target_8bit = ArithmeticTarget8Bit::C;
         instruct.bit_index = 0;
 
         c.registers.c = 255;
@@ -1343,7 +1343,7 @@ TEST_CASE("RESET Unit Tests", "[cpu][bit_opcode][reset]") {
 
     SECTION ("RESET 6") {
         CPU c;
-        instruct.target = ArithmeticTarget8Bit::D;
+        instruct.target_8bit = ArithmeticTarget8Bit::D;
         instruct.bit_index = 0;
 
         c.registers.d = 255;
@@ -1355,7 +1355,7 @@ TEST_CASE("RESET Unit Tests", "[cpu][bit_opcode][reset]") {
 
     SECTION ("RESET 7") {
         CPU c;
-        instruct.target = ArithmeticTarget8Bit::E;
+        instruct.target_8bit = ArithmeticTarget8Bit::E;
         instruct.bit_index = 0;
 
         c.registers.e = 255;
@@ -1367,7 +1367,7 @@ TEST_CASE("RESET Unit Tests", "[cpu][bit_opcode][reset]") {
 
     SECTION ("RESET 8") {
         CPU c;
-        instruct.target = ArithmeticTarget8Bit::H;
+        instruct.target_8bit = ArithmeticTarget8Bit::H;
         instruct.bit_index = 0;
 
         c.registers.h = 255;
@@ -1379,7 +1379,7 @@ TEST_CASE("RESET Unit Tests", "[cpu][bit_opcode][reset]") {
 
     SECTION ("RESET 9") {
         CPU c;
-        instruct.target = ArithmeticTarget8Bit::L;
+        instruct.target_8bit = ArithmeticTarget8Bit::L;
         instruct.bit_index = 0;
 
         c.registers.l = 255;
@@ -1387,5 +1387,105 @@ TEST_CASE("RESET Unit Tests", "[cpu][bit_opcode][reset]") {
         c.execute(instruct);
 
         REQUIRE(c.registers.l == 0b11111110);
+    }
+}
+
+TEST_CASE("ADDHL Unit Tests", "[cpu][16-bit][addhl]") {
+    Instruction instruct;
+    instruct.type = InstructionType::ADDHL;
+
+
+    SECTION ("ADDHL w/o Overflow") {
+        CPU c;
+        instruct.target_16bit = ArithmeticTarget16Bit::BC;
+
+        c.registers.set_hl(1);
+        c.registers.set_bc(1);
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.get_hl() == 2);
+        REQUIRE(c.registers.f.zero == false);
+        REQUIRE(c.registers.f.subtract == false);
+        REQUIRE(c.registers.f.carry == false);
+        REQUIRE(c.registers.f.half_carry == false);
+    }
+
+    SECTION ("ADDHL w Overflow") {
+        CPU c;
+        instruct.target_16bit = ArithmeticTarget16Bit::BC;
+
+        c.registers.set_hl(65535);
+        c.registers.set_bc(1);
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.get_hl() == 0);
+        REQUIRE(c.registers.f.zero == false);
+        REQUIRE(c.registers.f.subtract == false);
+        REQUIRE(c.registers.f.carry == true);
+        REQUIRE(c.registers.f.half_carry == true);
+    }
+
+    SECTION ("ADDHL w Half Carry") {
+        CPU c;
+        instruct.target_16bit = ArithmeticTarget16Bit::BC;
+
+        c.registers.set_hl(4095);
+        c.registers.set_bc(1);
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.get_hl() == 4096);
+        REQUIRE(c.registers.f.zero == false);
+        REQUIRE(c.registers.f.subtract == false);
+        REQUIRE(c.registers.f.carry == false);
+        REQUIRE(c.registers.f.half_carry == true);
+    }
+
+    SECTION ("ADDHL - DE") {
+        CPU c;
+        instruct.target_16bit = ArithmeticTarget16Bit::DE;
+
+        c.registers.set_hl(1);
+        c.registers.set_de(1);
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.get_hl() == 2);
+        REQUIRE(c.registers.f.zero == false);
+        REQUIRE(c.registers.f.subtract == false);
+        REQUIRE(c.registers.f.carry == false);
+        REQUIRE(c.registers.f.half_carry == false);
+    }
+
+    SECTION ("ADDHL - HL") {
+        CPU c;
+        instruct.target_16bit = ArithmeticTarget16Bit::HL;
+
+        c.registers.set_hl(1);
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.get_hl() == 2);
+        REQUIRE(c.registers.f.zero == false);
+        REQUIRE(c.registers.f.subtract == false);
+        REQUIRE(c.registers.f.carry == false);
+        REQUIRE(c.registers.f.half_carry == false);
+    }
+
+    SECTION ("ADDHL - SP") {
+        CPU c;
+        instruct.target_16bit = ArithmeticTarget16Bit::SP;
+
+        c.registers.set_hl(1);
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.get_hl() == 65535);
+        REQUIRE(c.registers.f.zero == false);
+        REQUIRE(c.registers.f.subtract == false);
+        REQUIRE(c.registers.f.carry == false);
+        REQUIRE(c.registers.f.half_carry == false);
     }
 }

--- a/tests/cpu_tests.cpp
+++ b/tests/cpu_tests.cpp
@@ -21,7 +21,7 @@ TEST_CASE("Default constructor initializes CPU successfully", "[cpu]") {
 TEST_CASE("ADD Unit Tests", "[cpu][8-bit][add]") {
     Instruction instruct;
     instruct.type = InstructionType::ADD;
-    instruct.target = ArithmeticTarget::B;
+    instruct.target = ArithmeticTarget8Bit::B;
 
     SECTION ("ADD w/o Overflow") {
         CPU c1;
@@ -87,7 +87,7 @@ TEST_CASE("ADD Unit Tests", "[cpu][8-bit][add]") {
 TEST_CASE("ADC Unit Tests", "[cpu][8-bit][adc]") {
     Instruction instruct;
     instruct.type = InstructionType::ADC;
-    instruct.target = ArithmeticTarget::B;
+    instruct.target = ArithmeticTarget8Bit::B;
 
     SECTION ("ADC w/o Overflow - No Carry") {
         CPU c1;
@@ -157,7 +157,7 @@ TEST_CASE("ADC Unit Tests", "[cpu][8-bit][adc]") {
 TEST_CASE("SUB Unit Tests", "[cpu][8-bit][sub]") {
     Instruction instruct;
     instruct.type = InstructionType::SUB;
-    instruct.target = ArithmeticTarget::B;
+    instruct.target = ArithmeticTarget8Bit::B;
 
     SECTION ("SUB w/o Overflow") {
         CPU c1;
@@ -207,7 +207,7 @@ TEST_CASE("SUB Unit Tests", "[cpu][8-bit][sub]") {
 TEST_CASE("SBC Unit Tests", "[cpu][8-bit][sbc]") {
     Instruction instruct;
     instruct.type = InstructionType::SBC;
-    instruct.target = ArithmeticTarget::B;
+    instruct.target = ArithmeticTarget8Bit::B;
 
     SECTION ("SBC w/o Overflow - No Carry") {
         CPU c1;
@@ -245,7 +245,7 @@ TEST_CASE("SBC Unit Tests", "[cpu][8-bit][sbc]") {
 TEST_CASE("AND Unit Tests", "[cpu][8-bit][and]") {
     Instruction instruct;
     instruct.type = InstructionType::AND;
-    instruct.target = ArithmeticTarget::B;
+    instruct.target = ArithmeticTarget8Bit::B;
 
     SECTION ("AND - No Zero") {
         CPU c1;
@@ -281,7 +281,7 @@ TEST_CASE("AND Unit Tests", "[cpu][8-bit][and]") {
 TEST_CASE("OR Unit Tests", "[cpu][8-bit][or]") {
     Instruction instruct;
     instruct.type = InstructionType::OR;
-    instruct.target = ArithmeticTarget::B;
+    instruct.target = ArithmeticTarget8Bit::B;
 
     SECTION ("OR - No Zero") {
         CPU c1;
@@ -317,7 +317,7 @@ TEST_CASE("OR Unit Tests", "[cpu][8-bit][or]") {
 TEST_CASE("XOR Unit Tests", "[cpu][8-bit][xor]") {
     Instruction instruct;
     instruct.type = InstructionType::XOR;
-    instruct.target = ArithmeticTarget::B;
+    instruct.target = ArithmeticTarget8Bit::B;
 
     SECTION ("XOR 1") {
         CPU c1;
@@ -353,7 +353,7 @@ TEST_CASE("XOR Unit Tests", "[cpu][8-bit][xor]") {
 TEST_CASE("CP Unit Tests", "[cpu][8-bit][cp]") {
     Instruction instruct;
     instruct.type = InstructionType::CP;
-    instruct.target = ArithmeticTarget::B;
+    instruct.target = ArithmeticTarget8Bit::B;
 
     SECTION ("CP w/o Overflow") {
         CPU c1;
@@ -405,7 +405,7 @@ TEST_CASE("INC Unit Tests", "[cpu][8-bit][inc]") {
     instruct.type = InstructionType::INC;
 
     SECTION ("INC Register A") {
-        instruct.target = ArithmeticTarget::A;
+        instruct.target = ArithmeticTarget8Bit::A;
 
         CPU c;
 
@@ -421,7 +421,7 @@ TEST_CASE("INC Unit Tests", "[cpu][8-bit][inc]") {
     }
 
     SECTION ("INC Register B") {
-        instruct.target = ArithmeticTarget::B;
+        instruct.target = ArithmeticTarget8Bit::B;
 
         CPU c;
 
@@ -437,7 +437,7 @@ TEST_CASE("INC Unit Tests", "[cpu][8-bit][inc]") {
     }
 
     SECTION ("INC Register C") {
-        instruct.target = ArithmeticTarget::C;
+        instruct.target = ArithmeticTarget8Bit::C;
 
         CPU c;
 
@@ -453,7 +453,7 @@ TEST_CASE("INC Unit Tests", "[cpu][8-bit][inc]") {
     }
 
     SECTION ("INC Register D") {
-        instruct.target = ArithmeticTarget::D;
+        instruct.target = ArithmeticTarget8Bit::D;
 
         CPU c;
 
@@ -469,7 +469,7 @@ TEST_CASE("INC Unit Tests", "[cpu][8-bit][inc]") {
     }
 
     SECTION ("INC Register E") {
-        instruct.target = ArithmeticTarget::E;
+        instruct.target = ArithmeticTarget8Bit::E;
 
         CPU c;
 
@@ -485,7 +485,7 @@ TEST_CASE("INC Unit Tests", "[cpu][8-bit][inc]") {
     }
 
     SECTION ("INC Register H") {
-        instruct.target = ArithmeticTarget::H;
+        instruct.target = ArithmeticTarget8Bit::H;
 
         CPU c;
 
@@ -501,7 +501,7 @@ TEST_CASE("INC Unit Tests", "[cpu][8-bit][inc]") {
     }
 
     SECTION ("INC Register L") {
-        instruct.target = ArithmeticTarget::L;
+        instruct.target = ArithmeticTarget8Bit::L;
 
         CPU c;
 
@@ -517,7 +517,7 @@ TEST_CASE("INC Unit Tests", "[cpu][8-bit][inc]") {
     }
 
     SECTION ("INC - Overflow - Carry Set to False") {
-        instruct.target = ArithmeticTarget::B;
+        instruct.target = ArithmeticTarget8Bit::B;
 
         CPU c;
 
@@ -534,7 +534,7 @@ TEST_CASE("INC Unit Tests", "[cpu][8-bit][inc]") {
     }
 
     SECTION ("INC - Overflow - Carry Set to True") {
-        instruct.target = ArithmeticTarget::B;
+        instruct.target = ArithmeticTarget8Bit::B;
 
         CPU c;
 
@@ -551,7 +551,7 @@ TEST_CASE("INC Unit Tests", "[cpu][8-bit][inc]") {
     }
 
     SECTION ("INC - Half Carry") {
-        instruct.target = ArithmeticTarget::B;
+        instruct.target = ArithmeticTarget8Bit::B;
 
         CPU c;
 
@@ -572,7 +572,7 @@ TEST_CASE("DEC Unit Tests", "[cpu][8-bit][dec]") {
     instruct.type = InstructionType::DEC;
 
     SECTION ("DEC Register A") {
-        instruct.target = ArithmeticTarget::A;
+        instruct.target = ArithmeticTarget8Bit::A;
 
         CPU c;
 
@@ -588,7 +588,7 @@ TEST_CASE("DEC Unit Tests", "[cpu][8-bit][dec]") {
     }
 
     SECTION ("DEC Register B") {
-        instruct.target = ArithmeticTarget::B;
+        instruct.target = ArithmeticTarget8Bit::B;
 
         CPU c;
 
@@ -604,7 +604,7 @@ TEST_CASE("DEC Unit Tests", "[cpu][8-bit][dec]") {
     }
 
     SECTION ("DEC Register C") {
-        instruct.target = ArithmeticTarget::C;
+        instruct.target = ArithmeticTarget8Bit::C;
 
         CPU c;
 
@@ -620,7 +620,7 @@ TEST_CASE("DEC Unit Tests", "[cpu][8-bit][dec]") {
     }
 
     SECTION ("DEC Register D") {
-        instruct.target = ArithmeticTarget::D;
+        instruct.target = ArithmeticTarget8Bit::D;
 
         CPU c;
 
@@ -636,7 +636,7 @@ TEST_CASE("DEC Unit Tests", "[cpu][8-bit][dec]") {
     }
 
     SECTION ("DEC Register E") {
-        instruct.target = ArithmeticTarget::E;
+        instruct.target = ArithmeticTarget8Bit::E;
 
         CPU c;
 
@@ -652,7 +652,7 @@ TEST_CASE("DEC Unit Tests", "[cpu][8-bit][dec]") {
     }
 
     SECTION ("DEC Register H") {
-        instruct.target = ArithmeticTarget::H;
+        instruct.target = ArithmeticTarget8Bit::H;
 
         CPU c;
 
@@ -668,7 +668,7 @@ TEST_CASE("DEC Unit Tests", "[cpu][8-bit][dec]") {
     }
 
     SECTION ("DEC Register L") {
-        instruct.target = ArithmeticTarget::L;
+        instruct.target = ArithmeticTarget8Bit::L;
 
         CPU c;
 
@@ -684,7 +684,7 @@ TEST_CASE("DEC Unit Tests", "[cpu][8-bit][dec]") {
     }
 
     SECTION ("DEC - Decrementing 0") {
-        instruct.target = ArithmeticTarget::B;
+        instruct.target = ArithmeticTarget8Bit::B;
 
         CPU c;
 
@@ -700,7 +700,7 @@ TEST_CASE("DEC Unit Tests", "[cpu][8-bit][dec]") {
     }
 
     SECTION ("DEC - Decrementing 1") {
-        instruct.target = ArithmeticTarget::B;
+        instruct.target = ArithmeticTarget8Bit::B;
 
         CPU c;
 
@@ -721,7 +721,7 @@ TEST_CASE("SWAP Unit Tests", "[cpu][misc][swap]") {
     instruct.type = InstructionType::SWAP;
 
     SECTION ("SWAP Register A") {
-        instruct.target = ArithmeticTarget::A;
+        instruct.target = ArithmeticTarget8Bit::A;
 
         CPU c;
 
@@ -737,7 +737,7 @@ TEST_CASE("SWAP Unit Tests", "[cpu][misc][swap]") {
     }
 
     SECTION ("SWAP Register B") {
-        instruct.target = ArithmeticTarget::B;
+        instruct.target = ArithmeticTarget8Bit::B;
 
         CPU c;
 
@@ -753,7 +753,7 @@ TEST_CASE("SWAP Unit Tests", "[cpu][misc][swap]") {
     }
 
     SECTION ("SWAP Register C") {
-        instruct.target = ArithmeticTarget::C;
+        instruct.target = ArithmeticTarget8Bit::C;
 
         CPU c;
 
@@ -769,7 +769,7 @@ TEST_CASE("SWAP Unit Tests", "[cpu][misc][swap]") {
     }
 
     SECTION ("SWAP Register D") {
-        instruct.target = ArithmeticTarget::D;
+        instruct.target = ArithmeticTarget8Bit::D;
 
         CPU c;
 
@@ -785,7 +785,7 @@ TEST_CASE("SWAP Unit Tests", "[cpu][misc][swap]") {
     }
 
     SECTION ("SWAP Register E") {
-        instruct.target = ArithmeticTarget::E;
+        instruct.target = ArithmeticTarget8Bit::E;
 
         CPU c;
 
@@ -801,7 +801,7 @@ TEST_CASE("SWAP Unit Tests", "[cpu][misc][swap]") {
     }
 
     SECTION ("SWAP Register H") {
-        instruct.target = ArithmeticTarget::H;
+        instruct.target = ArithmeticTarget8Bit::H;
 
         CPU c;
 
@@ -817,7 +817,7 @@ TEST_CASE("SWAP Unit Tests", "[cpu][misc][swap]") {
     }
 
     SECTION ("SWAP Register L") {
-        instruct.target = ArithmeticTarget::L;
+        instruct.target = ArithmeticTarget8Bit::L;
 
         CPU c;
 
@@ -1014,7 +1014,7 @@ TEST_CASE("BIT Unit Tests", "[cpu][bit_opcode][bit]") {
 
     SECTION ("BIT 1") {
         CPU c;
-        instruct.target = ArithmeticTarget::A;
+        instruct.target = ArithmeticTarget8Bit::A;
         instruct.bit_index = 3;
 
         c.registers.a = 0b00001000;
@@ -1029,7 +1029,7 @@ TEST_CASE("BIT Unit Tests", "[cpu][bit_opcode][bit]") {
 
     SECTION ("BIT 2") {
         CPU c;
-        instruct.target = ArithmeticTarget::A;
+        instruct.target = ArithmeticTarget8Bit::A;
         instruct.bit_index = 2;
 
         c.registers.a = 0b00001000;
@@ -1044,7 +1044,7 @@ TEST_CASE("BIT Unit Tests", "[cpu][bit_opcode][bit]") {
 
     SECTION ("BIT 3") {
         CPU c;
-        instruct.target = ArithmeticTarget::A;
+        instruct.target = ArithmeticTarget8Bit::A;
         instruct.bit_index = 4;
 
         c.registers.a = 0b00001000;
@@ -1059,7 +1059,7 @@ TEST_CASE("BIT Unit Tests", "[cpu][bit_opcode][bit]") {
 
     SECTION ("BIT 4") {
         CPU c;
-        instruct.target = ArithmeticTarget::B;
+        instruct.target = ArithmeticTarget8Bit::B;
         instruct.bit_index = 3;
 
         c.registers.b = 0b00001000;
@@ -1074,7 +1074,7 @@ TEST_CASE("BIT Unit Tests", "[cpu][bit_opcode][bit]") {
 
     SECTION ("BIT 5") {
         CPU c;
-        instruct.target = ArithmeticTarget::C;
+        instruct.target = ArithmeticTarget8Bit::C;
         instruct.bit_index = 3;
 
         c.registers.c = 0b00001000;
@@ -1089,7 +1089,7 @@ TEST_CASE("BIT Unit Tests", "[cpu][bit_opcode][bit]") {
 
     SECTION ("BIT 6") {
         CPU c;
-        instruct.target = ArithmeticTarget::D;
+        instruct.target = ArithmeticTarget8Bit::D;
         instruct.bit_index = 3;
 
         c.registers.d = 0b00001000;
@@ -1104,7 +1104,7 @@ TEST_CASE("BIT Unit Tests", "[cpu][bit_opcode][bit]") {
 
     SECTION ("BIT 7") {
         CPU c;
-        instruct.target = ArithmeticTarget::E;
+        instruct.target = ArithmeticTarget8Bit::E;
         instruct.bit_index = 3;
 
         c.registers.e = 0b00001000;
@@ -1119,7 +1119,7 @@ TEST_CASE("BIT Unit Tests", "[cpu][bit_opcode][bit]") {
 
     SECTION ("BIT 8") {
         CPU c;
-        instruct.target = ArithmeticTarget::H;
+        instruct.target = ArithmeticTarget8Bit::H;
         instruct.bit_index = 3;
 
         c.registers.h = 0b00001000;
@@ -1134,7 +1134,7 @@ TEST_CASE("BIT Unit Tests", "[cpu][bit_opcode][bit]") {
 
     SECTION ("BIT 9") {
         CPU c;
-        instruct.target = ArithmeticTarget::L;
+        instruct.target = ArithmeticTarget8Bit::L;
         instruct.bit_index = 3;
 
         c.registers.l = 0b00001000;
@@ -1149,7 +1149,7 @@ TEST_CASE("BIT Unit Tests", "[cpu][bit_opcode][bit]") {
 
     SECTION ("BIT 10 - Carry set to True") {
         CPU c;
-        instruct.target = ArithmeticTarget::A;
+        instruct.target = ArithmeticTarget8Bit::A;
         instruct.bit_index = 3;
 
         c.registers.a = 0b00001000;
@@ -1170,7 +1170,7 @@ TEST_CASE("SET Unit Tests", "[cpu][bit_opcode][set]") {
 
     SECTION ("SET 1") {
         CPU c;
-        instruct.target = ArithmeticTarget::A;
+        instruct.target = ArithmeticTarget8Bit::A;
         instruct.bit_index = 3;
 
         c.registers.a = 0;
@@ -1182,7 +1182,7 @@ TEST_CASE("SET Unit Tests", "[cpu][bit_opcode][set]") {
 
     SECTION ("SET 2") {
         CPU c;
-        instruct.target = ArithmeticTarget::A;
+        instruct.target = ArithmeticTarget8Bit::A;
         instruct.bit_index = 7;
 
         c.registers.a = 0;
@@ -1194,7 +1194,7 @@ TEST_CASE("SET Unit Tests", "[cpu][bit_opcode][set]") {
 
     SECTION ("SET 3") {
         CPU c;
-        instruct.target = ArithmeticTarget::A;
+        instruct.target = ArithmeticTarget8Bit::A;
         instruct.bit_index = 0;
 
         c.registers.a = 0;
@@ -1206,7 +1206,7 @@ TEST_CASE("SET Unit Tests", "[cpu][bit_opcode][set]") {
 
     SECTION ("SET 4") {
         CPU c;
-        instruct.target = ArithmeticTarget::B;
+        instruct.target = ArithmeticTarget8Bit::B;
         instruct.bit_index = 3;
 
         c.registers.b = 0;
@@ -1218,7 +1218,7 @@ TEST_CASE("SET Unit Tests", "[cpu][bit_opcode][set]") {
 
     SECTION ("SET 5") {
         CPU c;
-        instruct.target = ArithmeticTarget::C;
+        instruct.target = ArithmeticTarget8Bit::C;
         instruct.bit_index = 3;
 
         c.registers.c = 0;
@@ -1230,7 +1230,7 @@ TEST_CASE("SET Unit Tests", "[cpu][bit_opcode][set]") {
 
     SECTION ("SET 6") {
         CPU c;
-        instruct.target = ArithmeticTarget::D;
+        instruct.target = ArithmeticTarget8Bit::D;
         instruct.bit_index = 3;
 
         c.registers.d = 0;
@@ -1242,7 +1242,7 @@ TEST_CASE("SET Unit Tests", "[cpu][bit_opcode][set]") {
 
     SECTION ("SET 7") {
         CPU c;
-        instruct.target = ArithmeticTarget::E;
+        instruct.target = ArithmeticTarget8Bit::E;
         instruct.bit_index = 3;
 
         c.registers.e = 0;
@@ -1254,7 +1254,7 @@ TEST_CASE("SET Unit Tests", "[cpu][bit_opcode][set]") {
 
     SECTION ("SET 8") {
         CPU c;
-        instruct.target = ArithmeticTarget::H;
+        instruct.target = ArithmeticTarget8Bit::H;
         instruct.bit_index = 3;
 
         c.registers.h = 0;
@@ -1266,7 +1266,7 @@ TEST_CASE("SET Unit Tests", "[cpu][bit_opcode][set]") {
 
     SECTION ("SET 9") {
         CPU c;
-        instruct.target = ArithmeticTarget::L;
+        instruct.target = ArithmeticTarget8Bit::L;
         instruct.bit_index = 3;
 
         c.registers.l = 0;
@@ -1283,7 +1283,7 @@ TEST_CASE("RESET Unit Tests", "[cpu][bit_opcode][reset]") {
 
     SECTION ("RESET 1") {
         CPU c;
-        instruct.target = ArithmeticTarget::A;
+        instruct.target = ArithmeticTarget8Bit::A;
         instruct.bit_index = 3;
 
         c.registers.a = 255;
@@ -1295,7 +1295,7 @@ TEST_CASE("RESET Unit Tests", "[cpu][bit_opcode][reset]") {
 
     SECTION ("RESET 2") {
         CPU c;
-        instruct.target = ArithmeticTarget::A;
+        instruct.target = ArithmeticTarget8Bit::A;
         instruct.bit_index = 7;
 
         c.registers.a = 255;
@@ -1307,7 +1307,7 @@ TEST_CASE("RESET Unit Tests", "[cpu][bit_opcode][reset]") {
 
     SECTION ("RESET 3") {
         CPU c;
-        instruct.target = ArithmeticTarget::A;
+        instruct.target = ArithmeticTarget8Bit::A;
         instruct.bit_index = 0;
 
         c.registers.a = 255;
@@ -1319,7 +1319,7 @@ TEST_CASE("RESET Unit Tests", "[cpu][bit_opcode][reset]") {
 
     SECTION ("RESET 4") {
         CPU c;
-        instruct.target = ArithmeticTarget::B;
+        instruct.target = ArithmeticTarget8Bit::B;
         instruct.bit_index = 0;
 
         c.registers.b = 255;
@@ -1331,7 +1331,7 @@ TEST_CASE("RESET Unit Tests", "[cpu][bit_opcode][reset]") {
 
     SECTION ("RESET 5") {
         CPU c;
-        instruct.target = ArithmeticTarget::C;
+        instruct.target = ArithmeticTarget8Bit::C;
         instruct.bit_index = 0;
 
         c.registers.c = 255;
@@ -1343,7 +1343,7 @@ TEST_CASE("RESET Unit Tests", "[cpu][bit_opcode][reset]") {
 
     SECTION ("RESET 6") {
         CPU c;
-        instruct.target = ArithmeticTarget::D;
+        instruct.target = ArithmeticTarget8Bit::D;
         instruct.bit_index = 0;
 
         c.registers.d = 255;
@@ -1355,7 +1355,7 @@ TEST_CASE("RESET Unit Tests", "[cpu][bit_opcode][reset]") {
 
     SECTION ("RESET 7") {
         CPU c;
-        instruct.target = ArithmeticTarget::E;
+        instruct.target = ArithmeticTarget8Bit::E;
         instruct.bit_index = 0;
 
         c.registers.e = 255;
@@ -1367,7 +1367,7 @@ TEST_CASE("RESET Unit Tests", "[cpu][bit_opcode][reset]") {
 
     SECTION ("RESET 8") {
         CPU c;
-        instruct.target = ArithmeticTarget::H;
+        instruct.target = ArithmeticTarget8Bit::H;
         instruct.bit_index = 0;
 
         c.registers.h = 255;
@@ -1379,7 +1379,7 @@ TEST_CASE("RESET Unit Tests", "[cpu][bit_opcode][reset]") {
 
     SECTION ("RESET 9") {
         CPU c;
-        instruct.target = ArithmeticTarget::L;
+        instruct.target = ArithmeticTarget8Bit::L;
         instruct.bit_index = 0;
 
         c.registers.l = 255;


### PR DESCRIPTION
# Issue
https://github.com/Sam-Coburn/gameboy_emulator/issues/7

# Changes
- Implemented the following CPU instruction and also created unit test cases it:

1. ADDHL

# Test Results
<img width="706" height="497" alt="Screenshot 2026-04-15 at 9 44 15 PM" src="https://github.com/user-attachments/assets/eb106ce9-cec2-4215-a116-7840ec8bcc16" />
The code compiles successfully and all unit test cases pass successfully