### PR TITLE
Implementing Rotate and Shift Instructions in CPU Class

### DIFF
--- a/include/cpu.hpp
+++ b/include/cpu.hpp
@@ -18,7 +18,7 @@ enum class InstructionType {
     OR, XOR, CP, INC, DEC,
     SWAP, SCF, CCF, CPL, BIT,
     SET, RESET, ADDHL, RLCA, RLA,
-    RRCA, RRA, RLC
+    RRCA, RRA, RLC, RL
 };
 
 struct Instruction {
@@ -633,7 +633,7 @@ class CPU {
                     break;
                 }
 
-                // RLCA Instruction rotates the contents of the proviced register 1 bit to the left, the carry flag is set to old bit 7
+                // RLC Instruction rotates the contents of the proviced register 1 bit to the left, the carry flag is set to old bit 7
                 case InstructionType::RLC: {
                     switch (instruction.target_8bit) {
                         case ArithmeticTarget8Bit::A:
@@ -656,6 +656,35 @@ class CPU {
                             break;
                         case ArithmeticTarget8Bit::L:
                             registers.l = rlc(registers.l);
+                            break;
+                    }
+
+                    break;
+                }
+
+                // RL Instruction rotates the contents of the provided register 1 bit to the left, the carry flag is set to old bit 7, bit 0 is set to old carry flag value
+                case InstructionType::RL: {
+                    switch (instruction.target_8bit) {
+                        case ArithmeticTarget8Bit::A:
+                            registers.a = rla(registers.a);
+                            break;
+                        case ArithmeticTarget8Bit::B:
+                            registers.b = rla(registers.b);
+                            break;
+                        case ArithmeticTarget8Bit::C:
+                            registers.c = rla(registers.c);
+                            break;
+                        case ArithmeticTarget8Bit::D:
+                            registers.d = rla(registers.d);
+                            break;
+                        case ArithmeticTarget8Bit::E:
+                            registers.e = rla(registers.e);
+                            break;
+                        case ArithmeticTarget8Bit::H:
+                            registers.h = rla(registers.h);
+                            break;
+                        case ArithmeticTarget8Bit::L:
+                            registers.l = rla(registers.l);
                             break;
                     }
 
@@ -804,6 +833,20 @@ class CPU {
             bool new_carry = (value & 0b10000000) >> 7;
 
             uint8_t result = (value << 1) | (new_carry);
+
+            registers.f.zero = result == 0;
+            registers.f.subtract = false;
+            registers.f.carry = new_carry;
+            registers.f.half_carry = false;
+
+            return result;
+        }
+
+        uint8_t rla(uint8_t value) {
+            bool old_carry = registers.f.carry;
+            bool new_carry = (value & 0b10000000) >> 7;
+
+            uint8_t result = (value << 1) | (old_carry);
 
             registers.f.zero = result == 0;
             registers.f.subtract = false;

--- a/include/cpu.hpp
+++ b/include/cpu.hpp
@@ -19,7 +19,7 @@ enum class InstructionType {
     SWAP, SCF, CCF, CPL, BIT,
     SET, RESET, ADDHL, RLCA, RLA,
     RRCA, RRA, RLC, RL, RRC,
-    RR, SLA, SRA
+    RR, SLA, SRA, SRL
 };
 
 struct Instruction {
@@ -808,6 +808,35 @@ class CPU {
                     break;
                 }
 
+                // SRL Instruction shifts the value of the provided register to the right by 1 bit and stores old bit 0 in carry
+                case InstructionType::SRL: {
+                    switch (instruction.target_8bit) {
+                        case ArithmeticTarget8Bit::A:
+                            registers.a = srl(registers.a);
+                            break;
+                        case ArithmeticTarget8Bit::B:
+                            registers.b = srl(registers.b);
+                            break;
+                        case ArithmeticTarget8Bit::C:
+                            registers.c = srl(registers.c);
+                            break;
+                        case ArithmeticTarget8Bit::D:
+                            registers.d = srl(registers.d);
+                            break;
+                        case ArithmeticTarget8Bit::E:
+                            registers.e = srl(registers.e);
+                            break;
+                        case ArithmeticTarget8Bit::H:
+                            registers.h = srl(registers.h);
+                            break;
+                        case ArithmeticTarget8Bit::L:
+                            registers.l = srl(registers.l);
+                            break;
+                    }
+
+                    break;
+                }
+
                 default:
                     // TODO: support more instructions
                     break;
@@ -1017,6 +1046,19 @@ class CPU {
             bool msb = (value & 0b10000000) >> 7;
 
             uint8_t result = (value >> 1) | (msb << 7);
+
+            registers.f.zero = result == 0;
+            registers.f.subtract = false;
+            registers.f.carry = new_carry;
+            registers.f.half_carry = false;
+
+            return result;
+        }
+
+        uint8_t srl(uint8_t value) {
+            bool new_carry = value & 1;
+
+            uint8_t result = value >> 1;
 
             registers.f.zero = result == 0;
             registers.f.subtract = false;

--- a/include/cpu.hpp
+++ b/include/cpu.hpp
@@ -19,7 +19,7 @@ enum class InstructionType {
     SWAP, SCF, CCF, CPL, BIT,
     SET, RESET, ADDHL, RLCA, RLA,
     RRCA, RRA, RLC, RL, RRC,
-    RR
+    RR, SLA
 };
 
 struct Instruction {
@@ -750,6 +750,35 @@ class CPU {
                     break;
                 }
 
+                // SLA Instruction shifts the value of the provided register to the left by 1 bit and stores old bit 7 in carry
+                case InstructionType::SLA: {
+                    switch (instruction.target_8bit) {
+                        case ArithmeticTarget8Bit::A:
+                            registers.a = sla(registers.a);
+                            break;
+                        case ArithmeticTarget8Bit::B:
+                            registers.b = sla(registers.b);
+                            break;
+                        case ArithmeticTarget8Bit::C:
+                            registers.c = sla(registers.c);
+                            break;
+                        case ArithmeticTarget8Bit::D:
+                            registers.d = sla(registers.d);
+                            break;
+                        case ArithmeticTarget8Bit::E:
+                            registers.e = sla(registers.e);
+                            break;
+                        case ArithmeticTarget8Bit::H:
+                            registers.h = sla(registers.h);
+                            break;
+                        case ArithmeticTarget8Bit::L:
+                            registers.l = sla(registers.l);
+                            break;
+                    }
+
+                    break;
+                }
+
                 default:
                     // TODO: support more instructions
                     break;
@@ -933,6 +962,18 @@ class CPU {
             bool new_carry = value & 1;
 
             uint8_t result = (value >> 1) | (old_carry << 7);
+
+            registers.f.zero = result == 0;
+            registers.f.subtract = false;
+            registers.f.carry = new_carry;
+            registers.f.half_carry = false;
+
+            return result;
+        }
+
+        uint8_t sla(uint8_t value) {
+            bool new_carry = (value & 0b10000000) >> 7;
+            uint8_t result = value << 1;
 
             registers.f.zero = result == 0;
             registers.f.subtract = false;

--- a/include/cpu.hpp
+++ b/include/cpu.hpp
@@ -17,7 +17,7 @@ enum class InstructionType {
     ADD, ADC, SUB, SBC, AND,
     OR, XOR, CP, INC, DEC,
     SWAP, SCF, CCF, CPL, BIT,
-    SET, RESET, ADDHL, RRCA, RRA
+    SET, RESET, ADDHL, RLCA, RRCA, RRA
 };
 
 struct Instruction {
@@ -562,11 +562,29 @@ class CPU {
                     break;
                 }
 
+                // RLCA Instruction rotates the contents of register A 1 bit to the left, the carry flag is set to old bit 7
+                case InstructionType::RLCA: {
+                    uint8_t value = registers.a;
+                    bool new_carry = (value & 0b10000000) >> 7;
+
+                    value = (value << 1) | (new_carry);
+
+                    registers.a = value;
+
+                    registers.f.zero = registers.a == 0;
+                    registers.f.subtract = false;
+                    registers.f.carry = new_carry;
+                    registers.f.half_carry = false;
+
+                    break;
+                }
+
                 // RRCA Instruction rotates the contents of register A 1 bit to the right, the carry flag is set to old bit 0
                 case InstructionType::RRCA: {
                     uint8_t value = registers.a;
                     bool new_carry = value & 1;
-                    value = value >> 1;
+
+                    value = (value >> 1) | (new_carry << 7);
 
                     registers.a = value;
 

--- a/include/cpu.hpp
+++ b/include/cpu.hpp
@@ -18,7 +18,7 @@ enum class InstructionType {
     OR, XOR, CP, INC, DEC,
     SWAP, SCF, CCF, CPL, BIT,
     SET, RESET, ADDHL, RLCA, RLA,
-    RRCA, RRA, RLC, RL
+    RRCA, RRA, RLC, RL, RRC
 };
 
 struct Instruction {
@@ -691,6 +691,35 @@ class CPU {
                     break;
                 }
 
+                // RRC Instruction rotates the contents of the provided register 1 bit to the right, the carry flag is set to old bit 0
+                case InstructionType::RRC: {
+                    switch (instruction.target_8bit) {
+                        case ArithmeticTarget8Bit::A:
+                            registers.a = rrc(registers.a);
+                            break;
+                        case ArithmeticTarget8Bit::B:
+                            registers.b = rrc(registers.b);
+                            break;
+                        case ArithmeticTarget8Bit::C:
+                            registers.c = rrc(registers.c);
+                            break;
+                        case ArithmeticTarget8Bit::D:
+                            registers.d = rrc(registers.d);
+                            break;
+                        case ArithmeticTarget8Bit::E:
+                            registers.e = rrc(registers.e);
+                            break;
+                        case ArithmeticTarget8Bit::H:
+                            registers.h = rrc(registers.h);
+                            break;
+                        case ArithmeticTarget8Bit::L:
+                            registers.l = rrc(registers.l);
+                            break;
+                    }
+
+                    break;
+                }
+
                 default:
                     // TODO: support more instructions
                     break;
@@ -847,6 +876,19 @@ class CPU {
             bool new_carry = (value & 0b10000000) >> 7;
 
             uint8_t result = (value << 1) | (old_carry);
+
+            registers.f.zero = result == 0;
+            registers.f.subtract = false;
+            registers.f.carry = new_carry;
+            registers.f.half_carry = false;
+
+            return result;
+        }
+
+        uint8_t rrc(uint8_t value) {
+            bool new_carry = value & 1;
+
+            uint8_t result = (value >> 1) | (new_carry << 7);
 
             registers.f.zero = result == 0;
             registers.f.subtract = false;

--- a/include/cpu.hpp
+++ b/include/cpu.hpp
@@ -17,7 +17,7 @@ enum class InstructionType {
     ADD, ADC, SUB, SBC, AND,
     OR, XOR, CP, INC, DEC,
     SWAP, SCF, CCF, CPL, BIT,
-    SET, RESET, ADDHL, RLCA, RRCA, RRA
+    SET, RESET, ADDHL, RLCA, RLA, RRCA, RRA
 };
 
 struct Instruction {
@@ -568,6 +568,24 @@ class CPU {
                     bool new_carry = (value & 0b10000000) >> 7;
 
                     value = (value << 1) | (new_carry);
+
+                    registers.a = value;
+
+                    registers.f.zero = registers.a == 0;
+                    registers.f.subtract = false;
+                    registers.f.carry = new_carry;
+                    registers.f.half_carry = false;
+
+                    break;
+                }
+
+                // RLA Instruction rotates the contents of register A 1 bit to the left, the carry flag is set to old bit 7, bit 0 is set to old carry flag value
+                case InstructionType::RLA: {
+                    uint8_t value = registers.a;
+                    bool old_carry = registers.f.carry;
+                    bool new_carry = (value & 0b10000000) >> 7;
+
+                    value = (value << 1) | (old_carry);
 
                     registers.a = value;
 

--- a/include/cpu.hpp
+++ b/include/cpu.hpp
@@ -17,7 +17,7 @@ enum class InstructionType {
     ADD, ADC, SUB, SBC, AND,
     OR, XOR, CP, INC, DEC,
     SWAP, SCF, CCF, CPL, BIT,
-    SET, RESET, ADDHL, RRA
+    SET, RESET, ADDHL, RRCA, RRA
 };
 
 struct Instruction {
@@ -558,6 +558,22 @@ class CPU {
 
                     uint16_t new_value = add_hl(value);
                     registers.set_hl(new_value);
+
+                    break;
+                }
+
+                // RRCA Instruction rotates the contents of register A 1 bit to the right, the carry flag is set to old bit 0
+                case InstructionType::RRCA: {
+                    uint8_t value = registers.a;
+                    bool new_carry = value & 1;
+                    value = value >> 1;
+
+                    registers.a = value;
+
+                    registers.f.zero = registers.a == 0;
+                    registers.f.subtract = false;
+                    registers.f.carry = new_carry;
+                    registers.f.half_carry = false;
 
                     break;
                 }

--- a/include/cpu.hpp
+++ b/include/cpu.hpp
@@ -1,8 +1,9 @@
 #include <registers.hpp>
 
-#include <stdint.h>
-#include <iostream>
+#include <bit>
 #include <bitset>
+#include <iostream>
+#include <stdint.h>
 
 enum class ArithmeticTarget8Bit {
     A, B, C, D, E, H, L
@@ -16,7 +17,7 @@ enum class InstructionType {
     ADD, ADC, SUB, SBC, AND,
     OR, XOR, CP, INC, DEC,
     SWAP, SCF, CCF, CPL, BIT,
-    SET, RESET, ADDHL
+    SET, RESET, ADDHL, RRA
 };
 
 struct Instruction {
@@ -557,6 +558,24 @@ class CPU {
 
                     uint16_t new_value = add_hl(value);
                     registers.set_hl(new_value);
+
+                    break;
+                }
+
+                // RRA Instruction rotates the contents of register A 1 bit to the right, the carry flag is rotated in for bit 7 (leftmost bit) and bit 0 is rotated out to the carry flag value
+                case InstructionType::RRA: {
+                    uint8_t value = registers.a;
+                    uint8_t old_carry = registers.f.carry;
+                    bool new_carry = value & 1;
+
+                    value = (value >> 1) | (old_carry << 7);
+
+                    registers.a = value;
+
+                    registers.f.zero = registers.a == 0;
+                    registers.f.subtract = false;
+                    registers.f.carry = new_carry;
+                    registers.f.half_carry = false;
 
                     break;
                 }

--- a/include/cpu.hpp
+++ b/include/cpu.hpp
@@ -19,7 +19,7 @@ enum class InstructionType {
     SWAP, SCF, CCF, CPL, BIT,
     SET, RESET, ADDHL, RLCA, RLA,
     RRCA, RRA, RLC, RL, RRC,
-    RR, SLA
+    RR, SLA, SRA
 };
 
 struct Instruction {
@@ -779,6 +779,35 @@ class CPU {
                     break;
                 }
 
+                // SRA Instruction shifts the value of the provided register to the right by 1 bit and stores old bit 0 in carry, the MSB remains the same (don't shift in 0 automatically)
+                case InstructionType::SRA: {
+                    switch (instruction.target_8bit) {
+                        case ArithmeticTarget8Bit::A:
+                            registers.a = sra(registers.a);
+                            break;
+                        case ArithmeticTarget8Bit::B:
+                            registers.b = sra(registers.b);
+                            break;
+                        case ArithmeticTarget8Bit::C:
+                            registers.c = sra(registers.c);
+                            break;
+                        case ArithmeticTarget8Bit::D:
+                            registers.d = sra(registers.d);
+                            break;
+                        case ArithmeticTarget8Bit::E:
+                            registers.e = sra(registers.e);
+                            break;
+                        case ArithmeticTarget8Bit::H:
+                            registers.h = sra(registers.h);
+                            break;
+                        case ArithmeticTarget8Bit::L:
+                            registers.l = sra(registers.l);
+                            break;
+                    }
+
+                    break;
+                }
+
                 default:
                     // TODO: support more instructions
                     break;
@@ -974,6 +1003,20 @@ class CPU {
         uint8_t sla(uint8_t value) {
             bool new_carry = (value & 0b10000000) >> 7;
             uint8_t result = value << 1;
+
+            registers.f.zero = result == 0;
+            registers.f.subtract = false;
+            registers.f.carry = new_carry;
+            registers.f.half_carry = false;
+
+            return result;
+        }
+
+        uint8_t sra(uint8_t value) {
+            bool new_carry = value & 1;
+            bool msb = (value & 0b10000000) >> 7;
+
+            uint8_t result = (value >> 1) | (msb << 7);
 
             registers.f.zero = result == 0;
             registers.f.subtract = false;

--- a/include/cpu.hpp
+++ b/include/cpu.hpp
@@ -18,7 +18,8 @@ enum class InstructionType {
     OR, XOR, CP, INC, DEC,
     SWAP, SCF, CCF, CPL, BIT,
     SET, RESET, ADDHL, RLCA, RLA,
-    RRCA, RRA, RLC, RL, RRC
+    RRCA, RRA, RLC, RL, RRC,
+    RR
 };
 
 struct Instruction {
@@ -720,6 +721,35 @@ class CPU {
                     break;
                 }
 
+                // RR Instruction rotates the contents of the provided register 1 bit to the right, the carry flag is rotated in for bit 7 (leftmost bit) and bit 0 is rotated out to the carry flag value
+                case InstructionType::RR: {
+                    switch (instruction.target_8bit) {
+                        case ArithmeticTarget8Bit::A:
+                            registers.a = rr(registers.a);
+                            break;
+                        case ArithmeticTarget8Bit::B:
+                            registers.b = rr(registers.b);
+                            break;
+                        case ArithmeticTarget8Bit::C:
+                            registers.c = rr(registers.c);
+                            break;
+                        case ArithmeticTarget8Bit::D:
+                            registers.d = rr(registers.d);
+                            break;
+                        case ArithmeticTarget8Bit::E:
+                            registers.e = rr(registers.e);
+                            break;
+                        case ArithmeticTarget8Bit::H:
+                            registers.h = rr(registers.h);
+                            break;
+                        case ArithmeticTarget8Bit::L:
+                            registers.l = rr(registers.l);
+                            break;
+                    }
+
+                    break;
+                }
+
                 default:
                     // TODO: support more instructions
                     break;
@@ -889,6 +919,20 @@ class CPU {
             bool new_carry = value & 1;
 
             uint8_t result = (value >> 1) | (new_carry << 7);
+
+            registers.f.zero = result == 0;
+            registers.f.subtract = false;
+            registers.f.carry = new_carry;
+            registers.f.half_carry = false;
+
+            return result;
+        }
+
+        uint8_t rr(uint8_t value) {
+            uint8_t old_carry = registers.f.carry;
+            bool new_carry = value & 1;
+
+            uint8_t result = (value >> 1) | (old_carry << 7);
 
             registers.f.zero = result == 0;
             registers.f.subtract = false;

--- a/include/cpu.hpp
+++ b/include/cpu.hpp
@@ -17,7 +17,8 @@ enum class InstructionType {
     ADD, ADC, SUB, SBC, AND,
     OR, XOR, CP, INC, DEC,
     SWAP, SCF, CCF, CPL, BIT,
-    SET, RESET, ADDHL, RLCA, RLA, RRCA, RRA
+    SET, RESET, ADDHL, RLCA, RLA,
+    RRCA, RRA, RLC
 };
 
 struct Instruction {
@@ -632,6 +633,35 @@ class CPU {
                     break;
                 }
 
+                // RLCA Instruction rotates the contents of the proviced register 1 bit to the left, the carry flag is set to old bit 7
+                case InstructionType::RLC: {
+                    switch (instruction.target_8bit) {
+                        case ArithmeticTarget8Bit::A:
+                            registers.a = rlc(registers.a);
+                            break;
+                        case ArithmeticTarget8Bit::B:
+                            registers.b = rlc(registers.b);
+                            break;
+                        case ArithmeticTarget8Bit::C:
+                            registers.c = rlc(registers.c);
+                            break;
+                        case ArithmeticTarget8Bit::D:
+                            registers.d = rlc(registers.d);
+                            break;
+                        case ArithmeticTarget8Bit::E:
+                            registers.e = rlc(registers.e);
+                            break;
+                        case ArithmeticTarget8Bit::H:
+                            registers.h = rlc(registers.h);
+                            break;
+                        case ArithmeticTarget8Bit::L:
+                            registers.l = rlc(registers.l);
+                            break;
+                    }
+
+                    break;
+                }
+
                 default:
                     // TODO: support more instructions
                     break;
@@ -766,6 +796,19 @@ class CPU {
             registers.f.subtract = false;
             registers.f.carry = overflowed;
             registers.f.half_carry = (registers.get_hl() & 0xFFF) + (value & 0xFFF) > 0xFFF;
+
+            return result;
+        }
+
+        uint8_t rlc(uint8_t value) {
+            bool new_carry = (value & 0b10000000) >> 7;
+
+            uint8_t result = (value << 1) | (new_carry);
+
+            registers.f.zero = result == 0;
+            registers.f.subtract = false;
+            registers.f.carry = new_carry;
+            registers.f.half_carry = false;
 
             return result;
         }

--- a/tests/cpu_tests.cpp
+++ b/tests/cpu_tests.cpp
@@ -1490,6 +1490,57 @@ TEST_CASE("ADDHL Unit Tests", "[cpu][16-bit][addhl]") {
     }
 }
 
+TEST_CASE("RRCA Unit Tests", "[cpu][rotate][rrca]") {
+    Instruction instruct;
+    instruct.type = InstructionType::RRCA;
+
+
+    SECTION ("RRCA 1") {
+        CPU c;
+
+        c.registers.a = 0b00001001;
+        c.registers.f.carry = 1;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.a == 0b00000100);
+        REQUIRE(c.registers.f.zero == false);
+        REQUIRE(c.registers.f.subtract == false);
+        REQUIRE(c.registers.f.carry == true);
+        REQUIRE(c.registers.f.half_carry == false);
+    }
+
+    SECTION ("RRCA 2") {
+        CPU c;
+
+        c.registers.a = 0b00001001;
+        c.registers.f.carry = 0;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.a == 0b00000100);
+        REQUIRE(c.registers.f.zero == false);
+        REQUIRE(c.registers.f.subtract == false);
+        REQUIRE(c.registers.f.carry == true);
+        REQUIRE(c.registers.f.half_carry == false);
+    }
+
+    SECTION ("RRCA 3") {
+        CPU c;
+
+        c.registers.a = 0b00001000;
+        c.registers.f.carry = 0;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.a == 0b00000100);
+        REQUIRE(c.registers.f.zero == false);
+        REQUIRE(c.registers.f.subtract == false);
+        REQUIRE(c.registers.f.carry == false);
+        REQUIRE(c.registers.f.half_carry == false);
+    }
+}
+
 TEST_CASE("RRA Unit Tests", "[cpu][rotate][rra]") {
     Instruction instruct;
     instruct.type = InstructionType::RRA;

--- a/tests/cpu_tests.cpp
+++ b/tests/cpu_tests.cpp
@@ -1617,3 +1617,136 @@ TEST_CASE("RRA Unit Tests", "[cpu][rotate][rra]") {
         REQUIRE(c.registers.f.half_carry == false);
     }
 }
+
+TEST_CASE("RLC Unit Tests", "[cpu][rotate][rlc]") {
+    Instruction instruct;
+    instruct.type = InstructionType::RLC;
+
+    SECTION ("RLC 1") {
+        instruct.target_8bit = ArithmeticTarget8Bit::A;
+        CPU c;
+
+        c.registers.a = 0b00001001;
+        c.registers.f.carry = 1;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.a == 0b00010010);
+        REQUIRE(c.registers.f.zero == false);
+        REQUIRE(c.registers.f.subtract == false);
+        REQUIRE(c.registers.f.carry == false);
+        REQUIRE(c.registers.f.half_carry == false);
+    }
+
+    SECTION ("RLC 2") {
+        instruct.target_8bit = ArithmeticTarget8Bit::A;
+        CPU c;
+
+        c.registers.a = 0b10001001;
+        c.registers.f.carry = 1;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.a == 0b00010011);
+        REQUIRE(c.registers.f.zero == false);
+        REQUIRE(c.registers.f.subtract == false);
+        REQUIRE(c.registers.f.carry == true);
+        REQUIRE(c.registers.f.half_carry == false);
+    }
+
+    SECTION ("RLC 3") {
+        instruct.target_8bit = ArithmeticTarget8Bit::B;
+        CPU c;
+
+        c.registers.b = 0b00001001;
+        c.registers.f.carry = 1;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.b == 0b00010010);
+        REQUIRE(c.registers.f.zero == false);
+        REQUIRE(c.registers.f.subtract == false);
+        REQUIRE(c.registers.f.carry == false);
+        REQUIRE(c.registers.f.half_carry == false);
+    }
+
+    SECTION ("RLC 4") {
+        instruct.target_8bit = ArithmeticTarget8Bit::C;
+        CPU c;
+
+        c.registers.c = 0b00001001;
+        c.registers.f.carry = 1;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.c == 0b00010010);
+        REQUIRE(c.registers.f.zero == false);
+        REQUIRE(c.registers.f.subtract == false);
+        REQUIRE(c.registers.f.carry == false);
+        REQUIRE(c.registers.f.half_carry == false);
+    }
+
+    SECTION ("RLC 5") {
+        instruct.target_8bit = ArithmeticTarget8Bit::D;
+        CPU c;
+
+        c.registers.d = 0b00001001;
+        c.registers.f.carry = 1;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.d == 0b00010010);
+        REQUIRE(c.registers.f.zero == false);
+        REQUIRE(c.registers.f.subtract == false);
+        REQUIRE(c.registers.f.carry == false);
+        REQUIRE(c.registers.f.half_carry == false);
+    }
+
+    SECTION ("RLC 6") {
+        instruct.target_8bit = ArithmeticTarget8Bit::E;
+        CPU c;
+
+        c.registers.e = 0b00001001;
+        c.registers.f.carry = 1;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.e == 0b00010010);
+        REQUIRE(c.registers.f.zero == false);
+        REQUIRE(c.registers.f.subtract == false);
+        REQUIRE(c.registers.f.carry == false);
+        REQUIRE(c.registers.f.half_carry == false);
+    }
+
+    SECTION ("RLC 7") {
+        instruct.target_8bit = ArithmeticTarget8Bit::H;
+        CPU c;
+
+        c.registers.h = 0b00001001;
+        c.registers.f.carry = 1;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.h == 0b00010010);
+        REQUIRE(c.registers.f.zero == false);
+        REQUIRE(c.registers.f.subtract == false);
+        REQUIRE(c.registers.f.carry == false);
+        REQUIRE(c.registers.f.half_carry == false);
+    }
+
+    SECTION ("RLC 8") {
+        instruct.target_8bit = ArithmeticTarget8Bit::L;
+        CPU c;
+
+        c.registers.l = 0b00001001;
+        c.registers.f.carry = 1;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.l == 0b00010010);
+        REQUIRE(c.registers.f.zero == false);
+        REQUIRE(c.registers.f.subtract == false);
+        REQUIRE(c.registers.f.carry == false);
+        REQUIRE(c.registers.f.half_carry == false);
+    }
+}

--- a/tests/cpu_tests.cpp
+++ b/tests/cpu_tests.cpp
@@ -2371,3 +2371,139 @@ TEST_CASE("SRA Unit Tests", "[cpu][rotate][sra]") {
         REQUIRE(c.registers.f.half_carry == false);
     }
 }
+
+TEST_CASE("SRL Unit Tests", "[cpu][rotate][srl]") {
+    Instruction instruct;
+    instruct.type = InstructionType::SRL;
+
+
+    SECTION ("SRL 1") {
+        instruct.target_8bit = ArithmeticTarget8Bit::A;
+        CPU c;
+
+        c.registers.a = 0b00001001;
+        c.registers.f.carry = 0;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.a == 0b00000100);
+        REQUIRE(c.registers.f.zero == false);
+        REQUIRE(c.registers.f.subtract == false);
+        REQUIRE(c.registers.f.carry == 1);
+        REQUIRE(c.registers.f.half_carry == false);
+    }
+
+    SECTION ("SRL 2") {
+        instruct.target_8bit = ArithmeticTarget8Bit::A;
+        CPU c;
+
+        c.registers.a = 0b10000000;
+        c.registers.f.carry = 1;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.a == 0b01000000);
+        REQUIRE(c.registers.f.zero == false);
+        REQUIRE(c.registers.f.subtract == false);
+        REQUIRE(c.registers.f.carry == 0);
+        REQUIRE(c.registers.f.half_carry == false);
+    }
+
+    SECTION ("SRL 3") {
+        instruct.target_8bit = ArithmeticTarget8Bit::B;
+        CPU c;
+
+        c.registers.b = 0b10000000;
+        c.registers.f.carry = 1;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.b == 0b01000000);
+        REQUIRE(c.registers.f.zero == false);
+        REQUIRE(c.registers.f.subtract == false);
+        REQUIRE(c.registers.f.carry == 0);
+        REQUIRE(c.registers.f.half_carry == false);
+    }
+
+    SECTION ("SRL 4") {
+        instruct.target_8bit = ArithmeticTarget8Bit::C;
+        CPU c;
+
+        c.registers.c = 0b10000000;
+        c.registers.f.carry = 1;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.c == 0b01000000);
+        REQUIRE(c.registers.f.zero == false);
+        REQUIRE(c.registers.f.subtract == false);
+        REQUIRE(c.registers.f.carry == 0);
+        REQUIRE(c.registers.f.half_carry == false);
+    }
+
+    SECTION ("SRL 5") {
+        instruct.target_8bit = ArithmeticTarget8Bit::D;
+        CPU c;
+
+        c.registers.d = 0b10000000;
+        c.registers.f.carry = 1;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.d == 0b01000000);
+        REQUIRE(c.registers.f.zero == false);
+        REQUIRE(c.registers.f.subtract == false);
+        REQUIRE(c.registers.f.carry == 0);
+        REQUIRE
+        
+        (c.registers.f.half_carry == false);
+    }
+
+    SECTION ("SRL 6") {
+        instruct.target_8bit = ArithmeticTarget8Bit::E;
+        CPU c;
+
+        c.registers.e = 0b10000000;
+        c.registers.f.carry = 1;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.e == 0b01000000);
+        REQUIRE(c.registers.f.zero == false);
+        REQUIRE(c.registers.f.subtract == false);
+        REQUIRE(c.registers.f.carry == 0);
+        REQUIRE(c.registers.f.half_carry == false);
+    }
+
+    SECTION ("SRL 7") {
+        instruct.target_8bit = ArithmeticTarget8Bit::H;
+        CPU c;
+
+        c.registers.h = 0b10000000;
+        c.registers.f.carry = 1;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.h == 0b01000000);
+        REQUIRE(c.registers.f.zero == false);
+        REQUIRE(c.registers.f.subtract == false);
+        REQUIRE(c.registers.f.carry == 0);
+        REQUIRE(c.registers.f.half_carry == false);
+    }
+
+    SECTION ("SRL 8") {
+        instruct.target_8bit = ArithmeticTarget8Bit::L;
+        CPU c;
+
+        c.registers.l = 0b10000000;
+        c.registers.f.carry = 1;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.l == 0b01000000);
+        REQUIRE(c.registers.f.zero == false);
+        REQUIRE(c.registers.f.subtract == false);
+        REQUIRE(c.registers.f.carry == 0);
+        REQUIRE(c.registers.f.half_carry == false);
+    }
+}

--- a/tests/cpu_tests.cpp
+++ b/tests/cpu_tests.cpp
@@ -1867,3 +1867,121 @@ TEST_CASE("RL Unit Tests", "[cpu][rotate][rl]") {
         REQUIRE(c.registers.f.half_carry == false);
     }
 }
+
+TEST_CASE("RRC Unit Tests", "[cpu][rotate][rrc]") {
+    Instruction instruct;
+    instruct.type = InstructionType::RRC;
+
+
+    SECTION ("RRC 1") {
+        instruct.target_8bit = ArithmeticTarget8Bit::A;
+        CPU c;
+
+        c.registers.a = 0b00001001;
+        c.registers.f.carry = 1;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.a == 0b10000100);
+        REQUIRE(c.registers.f.zero == false);
+        REQUIRE(c.registers.f.subtract == false);
+        REQUIRE(c.registers.f.carry == true);
+        REQUIRE(c.registers.f.half_carry == false);
+    }
+
+    SECTION ("RRC 2") {
+        instruct.target_8bit = ArithmeticTarget8Bit::B;
+        CPU c;
+
+        c.registers.b = 0b00001001;
+        c.registers.f.carry = 1;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.b == 0b10000100);
+        REQUIRE(c.registers.f.zero == false);
+        REQUIRE(c.registers.f.subtract == false);
+        REQUIRE(c.registers.f.carry == true);
+        REQUIRE(c.registers.f.half_carry == false);
+    }
+
+    SECTION ("RRC 3") {
+        instruct.target_8bit = ArithmeticTarget8Bit::C;
+        CPU c;
+
+        c.registers.c = 0b00001001;
+        c.registers.f.carry = 1;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.c == 0b10000100);
+        REQUIRE(c.registers.f.zero == false);
+        REQUIRE(c.registers.f.subtract == false);
+        REQUIRE(c.registers.f.carry == true);
+        REQUIRE(c.registers.f.half_carry == false);
+    }
+
+    SECTION ("RRC 4") {
+        instruct.target_8bit = ArithmeticTarget8Bit::D;
+        CPU c;
+
+        c.registers.d = 0b00001001;
+        c.registers.f.carry = 1;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.d == 0b10000100);
+        REQUIRE(c.registers.f.zero == false);
+        REQUIRE(c.registers.f.subtract == false);
+        REQUIRE(c.registers.f.carry == true);
+        REQUIRE(c.registers.f.half_carry == false);
+    }
+
+    SECTION ("RRC 5") {
+        instruct.target_8bit = ArithmeticTarget8Bit::E;
+        CPU c;
+
+        c.registers.e = 0b00001001;
+        c.registers.f.carry = 1;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.e == 0b10000100);
+        REQUIRE(c.registers.f.zero == false);
+        REQUIRE(c.registers.f.subtract == false);
+        REQUIRE(c.registers.f.carry == true);
+        REQUIRE(c.registers.f.half_carry == false);
+    }
+
+    SECTION ("RRC 6") {
+        instruct.target_8bit = ArithmeticTarget8Bit::H;
+        CPU c;
+
+        c.registers.h = 0b00001001;
+        c.registers.f.carry = 1;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.h == 0b10000100);
+        REQUIRE(c.registers.f.zero == false);
+        REQUIRE(c.registers.f.subtract == false);
+        REQUIRE(c.registers.f.carry == true);
+        REQUIRE(c.registers.f.half_carry == false);
+    }
+
+    SECTION ("RRC 7") {
+        instruct.target_8bit = ArithmeticTarget8Bit::L;
+        CPU c;
+
+        c.registers.l = 0b00001001;
+        c.registers.f.carry = 1;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.l == 0b10000100);
+        REQUIRE(c.registers.f.zero == false);
+        REQUIRE(c.registers.f.subtract == false);
+        REQUIRE(c.registers.f.carry == true);
+        REQUIRE(c.registers.f.half_carry == false);
+    }
+}

--- a/tests/cpu_tests.cpp
+++ b/tests/cpu_tests.cpp
@@ -2103,3 +2103,137 @@ TEST_CASE("RR Unit Tests", "[cpu][rotate][rr]") {
         REQUIRE(c.registers.f.half_carry == false);
     }
 }
+
+TEST_CASE("SLA Unit Tests", "[cpu][rotate][sla]") {
+    Instruction instruct;
+    instruct.type = InstructionType::SLA;
+
+
+    SECTION ("SLA 1") {
+        instruct.target_8bit = ArithmeticTarget8Bit::A;
+        CPU c;
+
+        c.registers.a = 0b00001001;
+        c.registers.f.carry = 1;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.a == 0b00010010);
+        REQUIRE(c.registers.f.zero == false);
+        REQUIRE(c.registers.f.subtract == false);
+        REQUIRE(c.registers.f.carry == false);
+        REQUIRE(c.registers.f.half_carry == false);
+    }
+
+    SECTION ("SLA 2") {
+        instruct.target_8bit = ArithmeticTarget8Bit::A;
+        CPU c;
+
+        c.registers.a = 0b10101010;
+        c.registers.f.carry = 0;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.a == 0b01010100);
+        REQUIRE(c.registers.f.zero == false);
+        REQUIRE(c.registers.f.subtract == false);
+        REQUIRE(c.registers.f.carry == true);
+        REQUIRE(c.registers.f.half_carry == false);
+    }
+
+    SECTION ("SLA 3") {
+        instruct.target_8bit = ArithmeticTarget8Bit::B;
+        CPU c;
+
+        c.registers.b = 0b10101010;
+        c.registers.f.carry = 0;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.b == 0b01010100);
+        REQUIRE(c.registers.f.zero == false);
+        REQUIRE(c.registers.f.subtract == false);
+        REQUIRE(c.registers.f.carry == true);
+        REQUIRE(c.registers.f.half_carry == false);
+    }
+
+    SECTION ("SLA 4") {
+        instruct.target_8bit = ArithmeticTarget8Bit::C;
+        CPU c;
+
+        c.registers.c = 0b10101010;
+        c.registers.f.carry = 0;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.c == 0b01010100);
+        REQUIRE(c.registers.f.zero == false);
+        REQUIRE(c.registers.f.subtract == false);
+        REQUIRE(c.registers.f.carry == true);
+        REQUIRE(c.registers.f.half_carry == false);
+    }
+
+    SECTION ("SLA 5") {
+        instruct.target_8bit = ArithmeticTarget8Bit::D;
+        CPU c;
+
+        c.registers.d = 0b10101010;
+        c.registers.f.carry = 0;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.d == 0b01010100);
+        REQUIRE(c.registers.f.zero == false);
+        REQUIRE(c.registers.f.subtract == false);
+        REQUIRE(c.registers.f.carry == true);
+        REQUIRE(c.registers.f.half_carry == false);
+    }
+
+    SECTION ("SLA 6") {
+        instruct.target_8bit = ArithmeticTarget8Bit::E;
+        CPU c;
+
+        c.registers.e = 0b10101010;
+        c.registers.f.carry = 0;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.e == 0b01010100);
+        REQUIRE(c.registers.f.zero == false);
+        REQUIRE(c.registers.f.subtract == false);
+        REQUIRE(c.registers.f.carry == true);
+        REQUIRE(c.registers.f.half_carry == false);
+    }
+
+    SECTION ("SLA 7") {
+        instruct.target_8bit = ArithmeticTarget8Bit::H;
+        CPU c;
+
+        c.registers.h = 0b10101010;
+        c.registers.f.carry = 0;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.h == 0b01010100);
+        REQUIRE(c.registers.f.zero == false);
+        REQUIRE(c.registers.f.subtract == false);
+        REQUIRE(c.registers.f.carry == true);
+        REQUIRE(c.registers.f.half_carry == false);
+    }
+
+    SECTION ("SLA 8") {
+        instruct.target_8bit = ArithmeticTarget8Bit::L;
+        CPU c;
+
+        c.registers.l = 0b10101010;
+        c.registers.f.carry = 0;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.l == 0b01010100);
+        REQUIRE(c.registers.f.zero == false);
+        REQUIRE(c.registers.f.subtract == false);
+        REQUIRE(c.registers.f.carry == true);
+        REQUIRE(c.registers.f.half_carry == false);
+    }
+}

--- a/tests/cpu_tests.cpp
+++ b/tests/cpu_tests.cpp
@@ -1489,3 +1489,24 @@ TEST_CASE("ADDHL Unit Tests", "[cpu][16-bit][addhl]") {
         REQUIRE(c.registers.f.half_carry == false);
     }
 }
+
+TEST_CASE("RRA Unit Tests", "[cpu][rotate][rra]") {
+    Instruction instruct;
+    instruct.type = InstructionType::RRA;
+
+
+    SECTION ("RRA") {
+        CPU c;
+
+        c.registers.a = 0b00001001;
+        c.registers.f.carry = 1;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.a == 0b10000100);
+        REQUIRE(c.registers.f.zero == false);
+        REQUIRE(c.registers.f.subtract == false);
+        REQUIRE(c.registers.f.carry == true);
+        REQUIRE(c.registers.f.half_carry == false);
+    }
+}

--- a/tests/cpu_tests.cpp
+++ b/tests/cpu_tests.cpp
@@ -1750,3 +1750,120 @@ TEST_CASE("RLC Unit Tests", "[cpu][rotate][rlc]") {
         REQUIRE(c.registers.f.half_carry == false);
     }
 }
+
+TEST_CASE("RL Unit Tests", "[cpu][rotate][rl]") {
+    Instruction instruct;
+    instruct.type = InstructionType::RL;
+
+    SECTION ("RL 1") {
+        instruct.target_8bit = ArithmeticTarget8Bit::A;
+        CPU c;
+
+        c.registers.a = 0b00001001;
+        c.registers.f.carry = 1;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.a == 0b00010011);
+        REQUIRE(c.registers.f.zero == false);
+        REQUIRE(c.registers.f.subtract == false);
+        REQUIRE(c.registers.f.carry == false);
+        REQUIRE(c.registers.f.half_carry == false);
+    }
+
+    SECTION ("RL 2") {
+        instruct.target_8bit = ArithmeticTarget8Bit::B;
+        CPU c;
+
+        c.registers.b = 0b00001001;
+        c.registers.f.carry = 1;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.b == 0b00010011);
+        REQUIRE(c.registers.f.zero == false);
+        REQUIRE(c.registers.f.subtract == false);
+        REQUIRE(c.registers.f.carry == false);
+        REQUIRE(c.registers.f.half_carry == false);
+    }
+
+    SECTION ("RL 3") {
+        instruct.target_8bit = ArithmeticTarget8Bit::C;
+        CPU c;
+
+        c.registers.c = 0b00001001;
+        c.registers.f.carry = 1;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.c == 0b00010011);
+        REQUIRE(c.registers.f.zero == false);
+        REQUIRE(c.registers.f.subtract == false);
+        REQUIRE(c.registers.f.carry == false);
+        REQUIRE(c.registers.f.half_carry == false);
+    }
+
+    SECTION ("RL 4") {
+        instruct.target_8bit = ArithmeticTarget8Bit::D;
+        CPU c;
+
+        c.registers.d = 0b00001001;
+        c.registers.f.carry = 1;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.d == 0b00010011);
+        REQUIRE(c.registers.f.zero == false);
+        REQUIRE(c.registers.f.subtract == false);
+        REQUIRE(c.registers.f.carry == false);
+        REQUIRE(c.registers.f.half_carry == false);
+    }
+
+    SECTION ("RL 5") {
+        instruct.target_8bit = ArithmeticTarget8Bit::E;
+        CPU c;
+
+        c.registers.e = 0b00001001;
+        c.registers.f.carry = 1;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.e == 0b00010011);
+        REQUIRE(c.registers.f.zero == false);
+        REQUIRE(c.registers.f.subtract == false);
+        REQUIRE(c.registers.f.carry == false);
+        REQUIRE(c.registers.f.half_carry == false);
+    }
+
+    SECTION ("RL 6") {
+        instruct.target_8bit = ArithmeticTarget8Bit::H;
+        CPU c;
+
+        c.registers.h = 0b00001001;
+        c.registers.f.carry = 1;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.h == 0b00010011);
+        REQUIRE(c.registers.f.zero == false);
+        REQUIRE(c.registers.f.subtract == false);
+        REQUIRE(c.registers.f.carry == false);
+        REQUIRE(c.registers.f.half_carry == false);
+    }
+
+    SECTION ("RL 7") {
+        instruct.target_8bit = ArithmeticTarget8Bit::L;
+        CPU c;
+
+        c.registers.l = 0b00001001;
+        c.registers.f.carry = 1;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.l == 0b00010011);
+        REQUIRE(c.registers.f.zero == false);
+        REQUIRE(c.registers.f.subtract == false);
+        REQUIRE(c.registers.f.carry == false);
+        REQUIRE(c.registers.f.half_carry == false);
+    }
+}

--- a/tests/cpu_tests.cpp
+++ b/tests/cpu_tests.cpp
@@ -1526,6 +1526,26 @@ TEST_CASE("RLCA Unit Tests", "[cpu][rotate][rlca]") {
     }
 }
 
+TEST_CASE("RLA Unit Tests", "[cpu][rotate][rla]") {
+    Instruction instruct;
+    instruct.type = InstructionType::RLA;
+
+    SECTION ("RLA 1") {
+        CPU c;
+
+        c.registers.a = 0b00001001;
+        c.registers.f.carry = 1;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.a == 0b00010011);
+        REQUIRE(c.registers.f.zero == false);
+        REQUIRE(c.registers.f.subtract == false);
+        REQUIRE(c.registers.f.carry == false);
+        REQUIRE(c.registers.f.half_carry == false);
+    }
+}
+
 TEST_CASE("RRCA Unit Tests", "[cpu][rotate][rrca]") {
     Instruction instruct;
     instruct.type = InstructionType::RRCA;

--- a/tests/cpu_tests.cpp
+++ b/tests/cpu_tests.cpp
@@ -1985,3 +1985,121 @@ TEST_CASE("RRC Unit Tests", "[cpu][rotate][rrc]") {
         REQUIRE(c.registers.f.half_carry == false);
     }
 }
+
+TEST_CASE("RR Unit Tests", "[cpu][rotate][rr]") {
+    Instruction instruct;
+    instruct.type = InstructionType::RR;
+
+
+    SECTION ("RR 1") {
+        instruct.target_8bit = ArithmeticTarget8Bit::A;
+        CPU c;
+
+        c.registers.a = 0b00001001;
+        c.registers.f.carry = 1;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.a == 0b10000100);
+        REQUIRE(c.registers.f.zero == false);
+        REQUIRE(c.registers.f.subtract == false);
+        REQUIRE(c.registers.f.carry == true);
+        REQUIRE(c.registers.f.half_carry == false);
+    }
+
+    SECTION ("RR 2") {
+        instruct.target_8bit = ArithmeticTarget8Bit::B;
+        CPU c;
+
+        c.registers.b = 0b00001001;
+        c.registers.f.carry = 1;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.b == 0b10000100);
+        REQUIRE(c.registers.f.zero == false);
+        REQUIRE(c.registers.f.subtract == false);
+        REQUIRE(c.registers.f.carry == true);
+        REQUIRE(c.registers.f.half_carry == false);
+    }
+
+    SECTION ("RR 3") {
+        instruct.target_8bit = ArithmeticTarget8Bit::C;
+        CPU c;
+
+        c.registers.c = 0b00001001;
+        c.registers.f.carry = 1;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.c == 0b10000100);
+        REQUIRE(c.registers.f.zero == false);
+        REQUIRE(c.registers.f.subtract == false);
+        REQUIRE(c.registers.f.carry == true);
+        REQUIRE(c.registers.f.half_carry == false);
+    }
+
+    SECTION ("RR 4") {
+        instruct.target_8bit = ArithmeticTarget8Bit::D;
+        CPU c;
+
+        c.registers.d = 0b00001001;
+        c.registers.f.carry = 1;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.d == 0b10000100);
+        REQUIRE(c.registers.f.zero == false);
+        REQUIRE(c.registers.f.subtract == false);
+        REQUIRE(c.registers.f.carry == true);
+        REQUIRE(c.registers.f.half_carry == false);
+    }
+
+    SECTION ("RR 5") {
+        instruct.target_8bit = ArithmeticTarget8Bit::E;
+        CPU c;
+
+        c.registers.e = 0b00001001;
+        c.registers.f.carry = 1;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.e == 0b10000100);
+        REQUIRE(c.registers.f.zero == false);
+        REQUIRE(c.registers.f.subtract == false);
+        REQUIRE(c.registers.f.carry == true);
+        REQUIRE(c.registers.f.half_carry == false);
+    }
+
+    SECTION ("RR 6") {
+        instruct.target_8bit = ArithmeticTarget8Bit::H;
+        CPU c;
+
+        c.registers.h = 0b00001001;
+        c.registers.f.carry = 1;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.h == 0b10000100);
+        REQUIRE(c.registers.f.zero == false);
+        REQUIRE(c.registers.f.subtract == false);
+        REQUIRE(c.registers.f.carry == true);
+        REQUIRE(c.registers.f.half_carry == false);
+    }
+
+    SECTION ("RR 7") {
+        instruct.target_8bit = ArithmeticTarget8Bit::L;
+        CPU c;
+
+        c.registers.l = 0b00001001;
+        c.registers.f.carry = 1;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.l == 0b10000100);
+        REQUIRE(c.registers.f.zero == false);
+        REQUIRE(c.registers.f.subtract == false);
+        REQUIRE(c.registers.f.carry == true);
+        REQUIRE(c.registers.f.half_carry == false);
+    }
+}

--- a/tests/cpu_tests.cpp
+++ b/tests/cpu_tests.cpp
@@ -2237,3 +2237,137 @@ TEST_CASE("SLA Unit Tests", "[cpu][rotate][sla]") {
         REQUIRE(c.registers.f.half_carry == false);
     }
 }
+
+TEST_CASE("SRA Unit Tests", "[cpu][rotate][sra]") {
+    Instruction instruct;
+    instruct.type = InstructionType::SRA;
+
+
+    SECTION ("SRA 1") {
+        instruct.target_8bit = ArithmeticTarget8Bit::A;
+        CPU c;
+
+        c.registers.a = 0b00001001;
+        c.registers.f.carry = 0;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.a == 0b00000100);
+        REQUIRE(c.registers.f.zero == false);
+        REQUIRE(c.registers.f.subtract == false);
+        REQUIRE(c.registers.f.carry == 1);
+        REQUIRE(c.registers.f.half_carry == false);
+    }
+
+    SECTION ("SRA 2") {
+        instruct.target_8bit = ArithmeticTarget8Bit::A;
+        CPU c;
+
+        c.registers.a = 0b10000000;
+        c.registers.f.carry = 1;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.a == 0b11000000);
+        REQUIRE(c.registers.f.zero == false);
+        REQUIRE(c.registers.f.subtract == false);
+        REQUIRE(c.registers.f.carry == 0);
+        REQUIRE(c.registers.f.half_carry == false);
+    }
+
+    SECTION ("SRA 3") {
+        instruct.target_8bit = ArithmeticTarget8Bit::B;
+        CPU c;
+
+        c.registers.b = 0b00001001;
+        c.registers.f.carry = 0;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.b == 0b00000100);
+        REQUIRE(c.registers.f.zero == false);
+        REQUIRE(c.registers.f.subtract == false);
+        REQUIRE(c.registers.f.carry == 1);
+        REQUIRE(c.registers.f.half_carry == false);
+    }
+
+    SECTION ("SRA 4") {
+        instruct.target_8bit = ArithmeticTarget8Bit::C;
+        CPU c;
+
+        c.registers.c = 0b00001001;
+        c.registers.f.carry = 0;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.c == 0b00000100);
+        REQUIRE(c.registers.f.zero == false);
+        REQUIRE(c.registers.f.subtract == false);
+        REQUIRE(c.registers.f.carry == 1);
+        REQUIRE(c.registers.f.half_carry == false);
+    }
+
+    SECTION ("SRA 5") {
+        instruct.target_8bit = ArithmeticTarget8Bit::D;
+        CPU c;
+
+        c.registers.d = 0b00001001;
+        c.registers.f.carry = 0;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.d == 0b00000100);
+        REQUIRE(c.registers.f.zero == false);
+        REQUIRE(c.registers.f.subtract == false);
+        REQUIRE(c.registers.f.carry == 1);
+        REQUIRE(c.registers.f.half_carry == false);
+    }
+
+    SECTION ("SRA 6") {
+        instruct.target_8bit = ArithmeticTarget8Bit::E;
+        CPU c;
+
+        c.registers.e = 0b00001001;
+        c.registers.f.carry = 0;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.e == 0b00000100);
+        REQUIRE(c.registers.f.zero == false);
+        REQUIRE(c.registers.f.subtract == false);
+        REQUIRE(c.registers.f.carry == 1);
+        REQUIRE(c.registers.f.half_carry == false);
+    }
+
+    SECTION ("SRA 7") {
+        instruct.target_8bit = ArithmeticTarget8Bit::H;
+        CPU c;
+
+        c.registers.h = 0b00001001;
+        c.registers.f.carry = 0;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.h == 0b00000100);
+        REQUIRE(c.registers.f.zero == false);
+        REQUIRE(c.registers.f.subtract == false);
+        REQUIRE(c.registers.f.carry == 1);
+        REQUIRE(c.registers.f.half_carry == false);
+    }
+
+    SECTION ("SRA 8") {
+        instruct.target_8bit = ArithmeticTarget8Bit::L;
+        CPU c;
+
+        c.registers.l = 0b00001001;
+        c.registers.f.carry = 0;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.l == 0b00000100);
+        REQUIRE(c.registers.f.zero == false);
+        REQUIRE(c.registers.f.subtract == false);
+        REQUIRE(c.registers.f.carry == 1);
+        REQUIRE(c.registers.f.half_carry == false);
+    }
+}

--- a/tests/cpu_tests.cpp
+++ b/tests/cpu_tests.cpp
@@ -1490,6 +1490,42 @@ TEST_CASE("ADDHL Unit Tests", "[cpu][16-bit][addhl]") {
     }
 }
 
+TEST_CASE("RLCA Unit Tests", "[cpu][rotate][rlca]") {
+    Instruction instruct;
+    instruct.type = InstructionType::RLCA;
+
+
+    SECTION ("RLCA 1") {
+        CPU c;
+
+        c.registers.a = 0b00001001;
+        c.registers.f.carry = 1;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.a == 0b00010010);
+        REQUIRE(c.registers.f.zero == false);
+        REQUIRE(c.registers.f.subtract == false);
+        REQUIRE(c.registers.f.carry == false);
+        REQUIRE(c.registers.f.half_carry == false);
+    }
+
+    SECTION ("RLCA 2") {
+        CPU c;
+
+        c.registers.a = 0b10001001;
+        c.registers.f.carry = 1;
+
+        c.execute(instruct);
+
+        REQUIRE(c.registers.a == 0b00010011);
+        REQUIRE(c.registers.f.zero == false);
+        REQUIRE(c.registers.f.subtract == false);
+        REQUIRE(c.registers.f.carry == true);
+        REQUIRE(c.registers.f.half_carry == false);
+    }
+}
+
 TEST_CASE("RRCA Unit Tests", "[cpu][rotate][rrca]") {
     Instruction instruct;
     instruct.type = InstructionType::RRCA;
@@ -1503,7 +1539,7 @@ TEST_CASE("RRCA Unit Tests", "[cpu][rotate][rrca]") {
 
         c.execute(instruct);
 
-        REQUIRE(c.registers.a == 0b00000100);
+        REQUIRE(c.registers.a == 0b10000100);
         REQUIRE(c.registers.f.zero == false);
         REQUIRE(c.registers.f.subtract == false);
         REQUIRE(c.registers.f.carry == true);
@@ -1518,7 +1554,7 @@ TEST_CASE("RRCA Unit Tests", "[cpu][rotate][rrca]") {
 
         c.execute(instruct);
 
-        REQUIRE(c.registers.a == 0b00000100);
+        REQUIRE(c.registers.a == 0b10000100);
         REQUIRE(c.registers.f.zero == false);
         REQUIRE(c.registers.f.subtract == false);
         REQUIRE(c.registers.f.carry == true);


### PR DESCRIPTION
# Issue
https://github.com/Sam-Coburn/gameboy_emulator/issues/5

# Changes
- Implemented the following CPU instruction and also created unit test cases it:
1. RRA
2. RRCA
3. RLCA
4. RLA
5. RLC
6. RL
7. RRC
8. RR
9. SLA
10. SRA
11. SRL

# Test Results
<img width="692" height="497" alt="Screenshot 2026-04-25 at 3 41 08 PM" src="https://github.com/user-attachments/assets/a048d1cb-893a-4568-a982-38290bad9be7" />
The code compiles successfully and all unit test cases pass successfully